### PR TITLE
fix: hermitize block Lanczos matrices

### DIFF
--- a/src/block_lanczos.jl
+++ b/src/block_lanczos.jl
@@ -55,6 +55,9 @@ function block_lanczos(
         rmul!(M1, -1)
         mul!(V_new, V_old, M1, true, true) # V_new -= V*B'
     end
+    # hermitize matrices
+    map(hermitianpart!, A)
+    map(hermitianpart!, B)
     return A, B
 end
 

--- a/test/block_lanczos.jl
+++ b/test/block_lanczos.jl
@@ -36,6 +36,7 @@ using Test
         a, b = DMFT.block_lanczos(H, W, n_kryl)
         @test length(a) === n_kryl
         @test length(b) === n_kryl - 1
+        @test all(ishermitian, a)
         @test all(ishermitian, b)
 
         X = zeros(2 * n_kryl, 2 * n_kryl)


### PR DESCRIPTION
Analytically they must be hermitian. Enforce it in finite precision math.