### PR TITLE
fix!: enforce impurity Green's function to grid

### DIFF
--- a/src/dmft_step.jl
+++ b/src/dmft_step.jl
@@ -52,8 +52,7 @@ function dmft_step(
     G_plus = DMFT._pos(H, E0, ψ0, O, n_kryl)
     G_minus = DMFT._neg(H, E0, ψ0, O, n_kryl)
     G_imp = Pole([G_minus.a; G_plus.a], [G_minus.b; G_plus.b])
-    sort!(G_imp)
-    merge_equal_poles!(G_imp)
+    G_imp = to_grid(G_imp, Δ0.a)
 
     # self-energy
     Σ_H, Σ = self_energy_pole(ϵ_imp, Δ0, G_imp)


### PR DESCRIPTION
Enforcement fixes early breaking in DMFT self-consistency. Currently, no more LAPACK erros and loss of normalization when converting Pole to continued fraction.

But sum rules need to be loosened in tests.