### PR TITLE
fix: remove poles without any weight in inversion

### DIFF
--- a/src/pole.jl
+++ b/src/pole.jl
@@ -358,14 +358,17 @@ end
 """
     remove_poles_with_zero_weight!(P::Pole{<:Any,<:AbstractVector{<:Number}})
 
-Remove all poles ``|b_i|^2 = 0``.
+Remove all poles ``|b_i|^2 = 0`` excluding ``a_i = 0``.
 
 See also: [`remove_poles_with_zero_weight`](@ref).
 """
 function remove_poles_with_zero_weight!(P::Pole{<:Any,<:AbstractVector{<:Number}})
     i = firstindex(P.b)
     while i <= lastindex(P.b)
-        if iszero(P.b[i])
+        if iszero(P.a[i])
+            # keep pole at energy 0
+            i += 1
+        elseif iszero(P.b[i])
             popat!(P.a, i)
             popat!(P.b, i)
         else
@@ -378,7 +381,7 @@ end
 """
     remove_poles_with_zero_weight(P::Pole{<:Any,<:AbstractVector{<:Number}})
 
-Remove all poles ``|b_i|^2 = 0``.
+Remove all poles ``|b_i|^2 = 0`` excluding ``a_i = 0``.
 
 See also: [`remove_poles_with_zero_weight!`](@ref).
 """
@@ -451,7 +454,7 @@ P(z) = ∑_{i=1}^N \\frac{|b_i|^2}{z-a_i}
 is converted to
 
 ```math
-P_inv(z) = \\frac{1}{z - a_0 - \\sum_{i=1}^{N-1} \\frac{|b_i|^2}{z - a_i}} = \\frac{1}{z - a_0 - Q(z)}.
+P(z)^{1} = \\frac{1}{z - a_0 - \\sum_{i=1}^{N-1} \\frac{|b_i|^2}{z - a_i}} = \\frac{1}{z - a_0 - Q(z)}.
 ```
 
 Returns `a_0::Real` and `Q::Pole`.
@@ -460,6 +463,7 @@ Returns `a_0::Real` and `Q::Pole`.
     Input `P` must be normalized.
 """
 function Base.inv(P::Pole{<:V,<:V}) where {V<:AbstractVector{<:Real}}
+    P = remove_poles_with_zero_weight(P)
     a, b = _continued_fraction(P)
     a0 = a[1]
     # take all poles except first and diagonalize

--- a/test/pole.jl
+++ b/test/pole.jl
@@ -277,6 +277,13 @@ using Test
             @test remove_poles_with_zero_weight!(P) === P
             @test P.a == [2, 4]
             @test P.b == [7, 9]
+            # pole at a=0
+            a = [-1, 0, 5]
+            b = [2, 0, 3]
+            P = Pole(a, b)
+            @test remove_poles_with_zero_weight!(P) === P
+            @test P.a == [-1, 0, 5]
+            @test P.b == [2, 0, 3]
         end # remove poles with zero weight!
 
         @testset "remove poles with zero weight" begin
@@ -451,15 +458,16 @@ using Test
         end # -
 
         @testset "inv" begin
-            G = greens_function_bethe_simple(101)
+            grid = collect(range(-5, 5; length=1001))
+            G = greens_function_bethe_grid(grid)
             a0, P = inv(G)
-            @test length(P.a) === length(P.b) === 100
+            @test length(P.a) === length(P.b) === 200 # originally 201 poles with weight ≠ 0
             @test all(>=(0), P.b)
             # poles are symmetric
             @test abs(a0) < 2000 * eps()
             @test norm(P.a - P.a) < 10 * eps()
             @test norm(P.b - P.b) < 10 * eps()
-            @test sum(abs2.(P.b)) ≈ 0.25 atol = 300 * eps() # total weight
+            @test sum(abs2.(P.b)) ≈ 0.25 atol = 1e-4 # total weight
             # evaluate
             z = 0.1im
             @test norm(G(z) - 1 / (z - a0 - P(z))) < 30 * eps()


### PR DESCRIPTION
But keep pole at zero energy. This is necessary for paramagnetism in the insulating case.

This will hopefully remove LAPACAK errors.