### PR TITLE
refactor!: remove `update_hybridization_function` for grid

### DIFF
--- a/src/dmft_step.jl
+++ b/src/dmft_step.jl
@@ -46,7 +46,7 @@ function dmft_step(
         Δ, H_int, ϵ_imp, n_v_bit, n_c_bit, e, n_kryl_gs, n_kryl, O
     )
     Σ = self_energy_IFG(G_plus, G_minus, Z, Σ_H)
-    Δ_grid = update_hybridization_function(Δ0, μ, Z, Σ)
+    Δ_grid = Δ0(Z .+ μ - Σ)
     Δ_new = equal_weight_discretization(-imag(Δ_grid), real(Z), η, n_dis)
     return G_plus, G_minus, Δ_new, Δ_grid
 end
@@ -71,7 +71,7 @@ function dmft_step_gauss(
         Δ, H_int, ϵ_imp, n_v_bit, n_c_bit, e, n_kryl_gs, n_kryl, O
     )
     Σ = self_energy_IFG_gauss(G_plus, G_minus, ω, σ, Σ_H)
-    Δ_grid = update_hybridization_function(Δ0, μ, ω, Σ)
+    Δ_grid = Δ0(ω .+ μ - Σ)
     Δ_new = equal_weight_discretization(-imag(Δ_grid), real(ω), σ, n_dis)
     return G_plus, G_minus, Δ_new, Δ_grid
 end

--- a/src/update_hybridization_function.jl
+++ b/src/update_hybridization_function.jl
@@ -2,31 +2,6 @@
 
 """
     update_hybridization_function(
-        Δ0::Poles{<:Any,<:AbstractVector},
-        μ::Real,
-        Z::AbstractVector{<:Number},
-        Σ::AbstractVector{<:Complex},
-    )
-
-
-Calculate the new hybridization function from the lattice hybridization `Δ0` and
-the impurity self energy `Σ` on grid `Z`.
-
-```math
-Δ_z = Δ_0(z + μ - Σ_z)
-```
-"""
-function update_hybridization_function(
-    Δ0::Poles{<:Any,<:AbstractVector},
-    μ::Real,
-    Z::AbstractVector{<:Number},
-    Σ::AbstractVector{<:Complex},
-)
-    return Δ0(Z .+ μ - Σ)
-end
-
-"""
-    update_hybridization_function(
         Δ0::Poles{<:V,<:V}, μ::R, Σ_H::R, Σ::Poles{<:V,<:V}
     ) where {V<:AbstractVector{<:Real},R<:Real}
 

--- a/test/dmft_step.jl
+++ b/test/dmft_step.jl
@@ -85,7 +85,7 @@ using Test
 
         # FG
         Σ_FG = self_energy_FG(G_plus, G_minus, Z)
-        Δ_grid3 = update_hybridization_function(Δ0, μ, Z, Σ_FG)
+        Δ_grid3 = Δ0(Z .+ μ - Σ_FG)
         @test Δ_grid != Δ_grid3
     end # block Lanczos
 end # DMFT step


### PR DESCRIPTION
User can just directly evaluate object without extra function.