### PR TITLE
refactor!: rename starting wave function

### DIFF
--- a/src/DMFT.jl
+++ b/src/DMFT.jl
@@ -21,6 +21,8 @@ export
     PolesSumBlock,
 
     # Functions
+    CIWavefunction_singlet,
+    Wavefunction_singlet,
     amplitude,
     amplitudes,
     block_lanczos,
@@ -78,8 +80,6 @@ export
     slater_start,
     spectral_function_gauss,
     spectral_function_loggaussian,
-    starting_CIWavefunction,
-    starting_Wavefunction,
     sytrd!,
     temperature_kondo,
     to_grid,

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -41,7 +41,7 @@ function init_system(
     n_bit, n_v_vector, n_c_vector = get_CI_parameters(n_sites, n_occ, n_c_bit, n_v_bit)
     fs = FockSpace(Orbitals(n_bit), FermionicSpin(1//2))
     H = natural_orbital_ci_operator(H_nat, H_int, ϵ_imp, fs, n_occ, n_v_bit, n_c_bit, e)
-    ψ_start = starting_CIWavefunction(
+    ψ_start = CIWavefunction_singlet(
         Dict{UInt64,Float64}, n_v_bit, n_c_bit, n_v_vector, n_c_vector, e
     )
     E0, ψ0 = DMFT.ground_state(H, ψ_start, n_kryl)

--- a/src/wavefunctions.jl
+++ b/src/wavefunctions.jl
@@ -1,57 +1,44 @@
 # Methods related to `Fermions.Wavefunctions` module.
 
 """
-    starting_Wavefunction(
-        D::Type, n_v_bit::Int, n_c_bit::Int, n_v_vector::Int, n_c_vector::Int
+    Wavefunction_singlet(
+        D::Type, L_v::Integer, L_c::Integer, V_v::Integer, V_c::Integer
     )
 
-Return 2-determinant-state `Wavefunction` with
-opposite filling in impurity, mirror bath site.
+Initialize a `Wavefunction` with
+singlet in impurity and mirror site
+and all valence sites filled.
 """
-function starting_Wavefunction(
-    D::Type, n_v_bit::Int, n_c_bit::Int, n_v_vector::Int, n_c_vector::Int
+function Wavefunction_singlet(
+    D::Type, L_v::Integer, L_c::Integer, V_v::Integer, V_c::Integer
 )
     K, V = keytype(D), valtype(D)
-    s1 = slater_start(K, 0b0110, n_v_bit, n_c_bit, n_v_vector, n_c_vector)
-    s2 = slater_start(K, 0b1001, n_v_bit, n_c_bit, n_v_vector, n_c_vector)
-    result = Wavefunction(Dict(s1 => one(V), s2 => one(V)))
-    normalize!(result)
-    return result
+    s1 = slater_start(K, 0b0110, L_v, L_c, V_v, V_c)
+    s2 = slater_start(K, 0b1001, L_v, L_c, V_v, V_c)
+    return Wavefunction(Dict(s1 => V(1 / sqrt(2)), s2 => V(1 / sqrt(2))))
 end
 
 """
-    starting_CIWavefunction(
-        D::Type,
-        n_v_bit::Int,
-        n_c_bit::Int,
-        n_v_vector::Int,
-        n_c_vector::Int,
-        excitation::Int,
+    CIWavefunction_singlet(
+        D::Type, L_v::Integer, L_c::Integer, V_v::Integer, V_c::Integer, excitation::Integer
     )
 
-Return 2-determinant-state `CIWavefunction` with
-opposite filling in impurity, mirror bath site.
-
-E.g. `D = Dict{UInt64,Float64}` for bit component `UInt64`
-and vector component `Vector{Float64}`.
+Initialize a `CIWavefunction` with
+singlet in impurity and mirror site
+and all valence sites filled.
 """
-function starting_CIWavefunction(
-    D::Type, n_v_bit::Int, n_c_bit::Int, n_v_vector::Int, n_c_vector::Int, excitation::Int
+function CIWavefunction_singlet(
+    D::Type, L_v::Integer, L_c::Integer, V_v::Integer, V_c::Integer, excitation::Integer
 )
     K, V = keytype(D), valtype(D)
-    s1 = slater_start(K, 0b0110, n_v_bit, n_c_bit, 0, 0)
-    s2 = slater_start(K, 0b1001, n_v_bit, n_c_bit, 0, 0)
-    v_dim = sum(i -> binomial(2 * (n_v_vector + n_c_vector), i), 0:excitation)
-    v = zeros(V, v_dim)
-    v[1] = one(V)
+    s1 = slater_start(K, 0b0110, L_v, L_c, 0, 0)
+    s2 = slater_start(K, 0b1001, L_v, L_c, 0, 0)
+    v_dim = sum(i -> binomial(2 * (V_v + V_c), i), 0:excitation)
+    vec = zeros(V, v_dim)
+    vec[1] = 1 / sqrt(2)
     result = CIWavefunction(
-        Dict(s1 => copy(v), s2 => copy(v)),
-        2 + n_v_bit + n_c_bit,
-        n_v_vector,
-        n_c_vector,
-        excitation,
+        Dict(s1 => copy(vec), s2 => copy(vec)), 2 + L_v + L_c, V_v, V_c, excitation
     )
-    normalize!(result)
     return result
 end
 

--- a/test/wavefunctions.jl
+++ b/test/wavefunctions.jl
@@ -5,40 +5,44 @@ using LinearAlgebra
 using Test
 
 @testset "wavefunctions" begin
-    @testset "starting_Wavefunction" begin
-        ψ = starting_Wavefunction(Dict{UInt64,Float64}, 1, 2, 3, 4)
+    @testset "Wavefunction_singlet" begin
+        ψ = Wavefunction_singlet(Dict{UInt64,Float64}, 1, 2, 3, 4)
         d = Dict(
             UInt64(0b0000_111_00_1_01_0000_111_00_1_10) => 1 / sqrt(2),
             UInt64(0b0000_111_00_1_10_0000_111_00_1_01) => 1 / sqrt(2),
         )
         ϕ = Wavefunction(d)
         @test ψ == ϕ
-    end # starting_Wavefunction
+    end # Wavefunction_singlet
 
-    @testset "starting_CIWavefunction" begin
-        # e = 0
-        ψ = starting_CIWavefunction(Dict{UInt64,Float64}, 1, 2, 3, 4, 0)
+    @testset "CIWavefunction_singlet" begin
+        # excitation = 0
+        ψ = CIWavefunction_singlet(Dict{UInt64,Float64}, 1, 2, 3, 4, 0)
+        # vectors must be the equal but no egal
+        foo = collect(values(ψ))
+        @test foo[1] == foo[2]
+        @test foo[1] !== foo[2]
         v = [1 / sqrt(2)]
         d = Dict(UInt64(0b00_1_01_00_1_10) => copy(v), UInt64(0b00_1_10_00_1_01) => copy(v))
         ϕ = CIWavefunction(d, 5, 3, 4, 0)
         @test ψ == ϕ
 
-        # e = 1
-        ψ = starting_CIWavefunction(Dict{UInt64,Float64}, 1, 2, 3, 4, 1)
+        # excitation = 1
+        ψ = CIWavefunction_singlet(Dict{UInt64,Float64}, 1, 2, 3, 4, 1)
         v = zeros(1 + 2 * (3 + 4))
         v[1] = 1 / sqrt(2)
         d = Dict(UInt64(0b00_1_01_00_1_10) => copy(v), UInt64(0b00_1_10_00_1_01) => copy(v))
         ϕ = CIWavefunction(d, 5, 3, 4, 1)
         @test ψ == ϕ
 
-        # e = 2
-        ψ = starting_CIWavefunction(Dict{UInt64,Float64}, 1, 2, 3, 4, 2)
+        # excitation = 2
+        ψ = CIWavefunction_singlet(Dict{UInt64,Float64}, 1, 2, 3, 4, 2)
         v = zeros(1 + 14 + 14 * 13 ÷ 2)
         v[1] = 1 / sqrt(2)
         d = Dict(UInt64(0b00_1_01_00_1_10) => copy(v), UInt64(0b00_1_10_00_1_01) => copy(v))
         ϕ = CIWavefunction(d, 5, 3, 4, 2)
         @test ψ == ϕ
-    end # starting_CIWavefunction
+    end # CIWavefunction_singlet
 
     @testset "ground state" begin
         # parameters
@@ -63,7 +67,7 @@ using Test
             n = occupations(fs)
             H_int = U * n[1, -1//2] * n[1, 1//2]
             H = natural_orbital_operator(H_nat, H_int, -μ, fs, n_occ, n_v_bit, n_c_bit)
-            ϕ_start = starting_Wavefunction(
+            ϕ_start = Wavefunction_singlet(
                 Dict{M,Float64}, n_v_bit, n_c_bit, n_v_vector, n_c_vector
             )
             E0, ψ0 = DMFT.ground_state(H, ϕ_start, n_kryl)
@@ -84,7 +88,7 @@ using Test
             H = natural_orbital_ci_operator(
                 H_nat, H_int, -μ, fs, n_occ, n_v_bit, n_c_bit, e
             )
-            ψ_start = starting_CIWavefunction(
+            ψ_start = CIWavefunction_singlet(
                 Dict{UInt64,Float64}, n_v_bit, n_c_bit, n_v_vector, n_c_vector, e
             )
             _, _, states = lanczos_krylov(H, ψ_start, n_kryl)


### PR DESCRIPTION
Emphasize that it creates a singlet state.

- `starting_Wavefunction` → `Wavefunction_singlet`
- `starting_CIWavefunction` → `CIWavefunction_singlet`