### PR TITLE
refactor!: restructure ground state calculation

### DIFF
--- a/src/DMFT.jl
+++ b/src/DMFT.jl
@@ -48,7 +48,7 @@ export
     greens_function_partial,
     grid_interpolate,
     grid_log,
-    ground_state,
+    ground_state!,
     hybridization_function_bethe_analytic,
     hybridization_function_bethe_equal_weight,
     hybridization_function_bethe_grid,

--- a/src/correlator.jl
+++ b/src/correlator.jl
@@ -54,22 +54,21 @@ end
 
 """
     correlator_plus(
-        H::CIOperator, E0::Real, ψ0::CI, O::Operator, n_kryl::Int
+        H::CIOperator, ψ0::CI, O::Operator, n_kryl::Int
     ) where {CI<:CIWavefunction}
 
 Calculate the positive spectrum of the correlator.
 
 ```math
-C^+(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω - H + E_0} O ψ_0 \\right⟩
+C^+(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω - H} O ψ_0 \\right⟩
 ```
 
 See also [`correlator_minus`](@ref).
 """
 function correlator_plus(
-    H::CIOperator, E0::Real, ψ0::CI, O::Operator, n_kryl::Int
+    H::CIOperator, ψ0::CI, O::Operator, n_kryl::Int
 ) where {CI<:CIWavefunction}
     C = correlator(H, ψ0, O, n_kryl)
-    locations(C) .-= E0
 
     # poles at negative locatiions (never happens on exact arithmetic)
     idx_neg = findall(<(0), locations(C))
@@ -84,22 +83,21 @@ end
 
 """
     correlator_plus(
-        H::CIOperator, E0::Real, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
+        H::CIOperator, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
     ) where {CI<:CIWavefunction}
 
 Calculate the positive spectrum of the block correlator.
 
 ```math
-C^+(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω - H + E_0} O ψ_0 \\right⟩
+C^+(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω - H} O ψ_0 \\right⟩
 ```
 
 See also [`correlator_minus`](@ref).
 """
 function correlator_plus(
-    H::CIOperator, E0::Real, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
+    H::CIOperator, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
 ) where {CI<:CIWavefunction}
     C = correlator(H, ψ0, O, n_kryl)
-    locations(C) .-= E0
 
     # poles at negative energies (never happens on exact arithmetic)
     idx_neg = findall(<(0), locations(C))
@@ -113,22 +111,21 @@ end
 
 """
     correlator_minus(
-        H::CIOperator, E0::Real, ψ0::CI, O::Operator, n_kryl::Int
+        H::CIOperator, ψ0::CI, O::Operator, n_kryl::Int
     ) where {CI<:CIWavefunction}
 
 Calculate the negative spectrum of the correlator.
 
 ```math
-C^-(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω + H - E_0} O ψ_0 \\right⟩
+C^-(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω + H} O ψ_0 \\right⟩
 ```
 
 See also [`correlator_plus`](@ref).
 """
 function correlator_minus(
-    H::CIOperator, E0::Real, ψ0::CI, O::Operator, n_kryl::Int
+    H::CIOperator, ψ0::CI, O::Operator, n_kryl::Int
 ) where {CI<:CIWavefunction}
     C = correlator(H, ψ0, O, n_kryl)
-    locations(C) .-= E0
 
     map!(-, locations(C), locations(C)) # flip sign of eigenvalues
     reverse!(C) # order form lowest to highest
@@ -146,22 +143,21 @@ end
 
 """
     correlator_minus(
-        H::CIOperator, E0::Real, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
+        H::CIOperator, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
     ) where {CI<:CIWavefunction}
 
 Calculate the negative spectrum of the block correlator.
 
 ```math
-C^+(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω + H - E_0} O ψ_0 \\right⟩
+C^+(ω) = \\left⟨ ψ_0 O^† \\frac{1}{ω + H} O ψ_0 \\right⟩
 ```
 
 See also [`correlator_minus`](@ref).
 """
 function correlator_minus(
-    H::CIOperator, E0::Real, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
+    H::CIOperator, ψ0::CI, O::AbstractVector{<:Operator}, n_kryl::Int
 ) where {CI<:CIWavefunction}
     C = correlator(H, ψ0, O, n_kryl)
-    locations(C) .-= E0
 
     map!(-, locations(C), locations(C)) # flip sign of eigenvalues
     reverse!(C) # order form lowest to highest

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -15,36 +15,22 @@ end
 
 """
     init_system(
-        Δ::PolesSum,
-        H_int::Operator,
-        ϵ_imp::Real,
-        n_v_bit::Int,
-        n_c_bit::Int,
-        e::Int,
-        n_kryl::Int,
-    ) where {V<:AbstractVector{<:Real}}
+        Δ::PolesSum, H_int::Operator, ϵ_imp::Real, L_v::Int, L_c::Int, p::Int, var::Real
+    )
 
 Return Hamiltonian, ground state energy, and ground state.
 """
 function init_system(
-    Δ::PolesSum,
-    H_int::Operator,
-    ϵ_imp::Real,
-    n_v_bit::Int,
-    n_c_bit::Int,
-    e::Int,
-    n_kryl::Int,
+    Δ::PolesSum, H_int::Operator, ϵ_imp::Real, L_v::Int, L_c::Int, p::Int, var::Real
 )
     arr = Array(Δ)
     n_sites = size(arr, 1)
     H_nat, n_occ = to_natural_orbitals(arr)
-    n_bit, n_v_vector, n_c_vector = get_CI_parameters(n_sites, n_occ, n_c_bit, n_v_bit)
+    n_bit, V_v, V_c = get_CI_parameters(n_sites, n_occ, L_c, L_v)
     fs = FockSpace(Orbitals(n_bit), FermionicSpin(1//2))
-    H = natural_orbital_ci_operator(H_nat, H_int, ϵ_imp, fs, n_occ, n_v_bit, n_c_bit, e)
-    ψ_start = CIWavefunction_singlet(
-        Dict{UInt64,Float64}, n_v_bit, n_c_bit, n_v_vector, n_c_vector, e
-    )
-    E0, ψ0 = DMFT.ground_state(H, ψ_start, n_kryl)
+    H = natural_orbital_ci_operator(H_nat, H_int, ϵ_imp, fs, n_occ, L_v, L_c, p)
+    ψ_start = CIWavefunction_singlet(Dict{UInt64,Float64}, L_v, L_c, V_v, V_c, p)
+    E0, ψ0 = ground_state!(H, ψ_start, 5, typemax(Int), var)
     return H, E0, ψ0
 end
 

--- a/test/block_lanczos.jl
+++ b/test/block_lanczos.jl
@@ -14,7 +14,7 @@ using Test
         n_c_bit = 1
         e = 2
         n_kryl = 5
-        n_kryl_gs = 20
+        var = eps()
         # initial system
         Δ = hybridization_function_bethe_simple(n_bath, 2)
         fs = FockSpace(Orbitals(2 + n_v_bit + n_c_bit), FermionicSpin(1//2))
@@ -24,7 +24,7 @@ using Test
         d_dag = c[1, -1//2]' # d_↓^†
         q_dag = H_int * d_dag - d_dag * H_int  # q_↓^† = [H_int, d^†]
 
-        H, E0, ψ0 = init_system(Δ, H_int, -μ, n_v_bit, n_c_bit, e, n_kryl_gs)
+        H, E0, ψ0 = init_system(Δ, H_int, -μ, n_v_bit, n_c_bit, e, var)
         v1 = d_dag * ψ0
         v2 = q_dag * ψ0
         V0 = [v1 v2]
@@ -46,16 +46,16 @@ using Test
         X[(end - 1):end, (end - 1):end] = a[end] # last element
         E = eigvals(X)
         E_ref = [
-            -15.678942694187539,
-            -15.295686009018686,
-            -14.964415736054807,
-            -14.76013760998127,
-            -14.267760301388584,
-            -14.079691680430527,
-            -13.417532651434934,
-            -12.538689290677826,
-            -11.218209037339488,
-            -9.818357326067973,
+            0.214059965436778
+            0.5971189953214974
+            0.9281541797197747
+            1.132106853579721
+            1.6228297233186255
+            1.8127643102174924
+            2.4744861501689104
+            3.354246572428307
+            4.674799177427353
+            6.074676075106131
         ]
         @test norm(E - E_ref) < 3e3 * eps()
     end # block_lanczos

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -13,7 +13,7 @@ using Test
     n_c_bit = 1
     e = 1
     n_kryl = 100
-    n_kryl_gs = 20
+    var = eps()
     W = collect(-5:0.001:5)
     δ = 0.04
     # do not change parameters below
@@ -32,12 +32,12 @@ using Test
     O = [q_dag, d_dag]
 
     # initialize system
-    H, E0, ψ0 = init_system(Δ0, H_int, ϵ_imp, n_v_bit, n_c_bit, e, n_kryl_gs)
+    H, E0, ψ0 = init_system(Δ0, H_int, ϵ_imp, n_v_bit, n_c_bit, e, var)
 
     @testset "Lanczos" begin
         # impurity Green's functions
-        G_plus = correlator_plus(H, E0, ψ0, d_dag, n_kryl)
-        G_minus = correlator_minus(H, E0, ψ0, d_dag', n_kryl)
+        G_plus = correlator_plus(H, ψ0, d_dag, n_kryl)
+        G_minus = correlator_minus(H, ψ0, d_dag', n_kryl)
         G_imp = G_plus + G_minus
 
         # self-energy
@@ -52,7 +52,7 @@ using Test
 
         @test length(Δ_new) == 101
         @test iszero(locations(Δ_new)[51])
-        @test weight(Δ_new, 51) ≈ 0.002083461320853373 atol = 1e-7
+        @test weight(Δ_new, 51) ≈ 0.0020833288949242113 atol = 1e-7
         @test DMFT.moment(Δ_new, 0) ≈ 0.25 atol = 10 * eps()
         @test DMFT.moment(Δ_new, 1) ≈ 0.0 atol = sqrt(eps())
 
@@ -70,8 +70,8 @@ using Test
         Σ_H = dot(ψ0, O_H, ψ0)
 
         # impurity correlators
-        C_plus = correlator_plus(H, E0, ψ0, O, n_kryl)
-        C_minus = correlator_minus(H, E0, ψ0, map(adjoint, O), n_kryl)
+        C_plus = correlator_plus(H, ψ0, O, n_kryl)
+        C_minus = correlator_minus(H, ψ0, map(adjoint, O), n_kryl)
         C = transpose(C_minus) + C_plus
 
         # Lorentzian

--- a/test/self_energy.jl
+++ b/test/self_energy.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 using Test
 
 @testset "self-energy" begin
+    # parameters
     n_bath = 31
     U = 4.0
     μ = U / 2
@@ -12,7 +13,7 @@ using Test
     L_c = 1
     p = 2
     n_kryl = 100
-    n_kryl_gs = 20
+    var = eps()
     step_size = 0.02
     W = collect(-10:step_size:10)
     δ = 0.08
@@ -29,7 +30,7 @@ using Test
     # only interacting part
     H_int = U * n[1, 1//2] * n[1, -1//2]
     q_dag = H_int * d_dag - d_dag * H_int  # q_↓^† = [H_int, d^†]
-    H, E0, ψ0 = init_system(Δ0, H_int, ϵ_imp, L_v, L_c, p, n_kryl_gs)
+    H, E0, ψ0 = init_system(Δ0, H_int, ϵ_imp, L_v, L_c, p, var)
     O_Σ_H = q_dag' * d_dag + d_dag * q_dag'
     Σ_H = dot(ψ0, O_Σ_H, ψ0)
 
@@ -38,8 +39,8 @@ using Test
     O = [q_dag_tilde, d_dag]
 
     # impurity solver
-    C_plus = correlator_plus(H, E0, ψ0, O, n_kryl)
-    C_minus = correlator_minus(H, E0, ψ0, map(adjoint, O), n_kryl)
+    C_plus = correlator_plus(H, ψ0, O, n_kryl)
+    C_minus = correlator_minus(H, ψ0, map(adjoint, O), n_kryl)
     C = transpose(C_minus) + C_plus
     merge_small_weight!(C, tol)
 
@@ -62,7 +63,7 @@ using Test
         # on the real axis
         Σ = self_energy_IFG(C)
         merge_small_weight!(Σ, tol)
-        @test DMFT.moment(Σ, 0) ≈ U^2 / 4 rtol = 1e-12
+        @test DMFT.moment(Σ, 0) ≈ U^2 / 4 rtol = 2e-12
         @test DMFT.moment(Σ, 1) ≈ 0 atol = 1e-9
         # broadened
         Σ_IFG_lorentz = self_energy_IFG_lorentzian(Σ_H, C, W, δ)

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -25,24 +25,22 @@ using Test
         n_bath = 31
         U = 4.0
         μ = U / 2
-        n_v_bit = 1
-        n_c_bit = 1
-        e = 2
+        L_v = 1
+        L_c = 1
+        p = 2
         n_kryl = 15
-        E0_target = -21.527949603162277 # target ground state energy
+        var = eps()
+
+        E0_target = -21.527949990417255 # target ground state energy
         Δ = hybridization_function_bethe_simple(n_bath)
-        fs = FockSpace(Orbitals(2 + n_v_bit + n_c_bit), FermionicSpin(1//2))
+        fs = FockSpace(Orbitals(2 + L_v + L_c), FermionicSpin(1//2))
         n = occupations(fs)
         H_int = U * n[1, -1//2] * n[1, 1//2]
-        H, E0, ψ0 = init_system(Δ, H_int, -μ, n_v_bit, n_c_bit, e, n_kryl)
+        H, E0, ψ0 = init_system(Δ, H_int, -μ, L_v, L_c, p, eps())
         Hψ = H * ψ0
-        H_avg = dot(ψ0, Hψ)
-        H_sqr = dot(Hψ, Hψ)
-        var_rel = H_sqr / H_avg^2 - 1
-        @test H isa CIOperator
-        @test abs(E0 / E0_target - 1) < 1e-4
-        @test abs(H_avg / E0 - 1) < 1e-14
-        @test var_rel < 4e-8
+        variance = Hψ ⋅ Hψ
+        @test variance < var
+        @test E0 ≈ E0_target atol = 1e-13
     end # init system
 
     @testset "δ_gaussian" begin


### PR DESCRIPTION
Instead of doing one calculation with a big Krylov space, do many restarts with a few Krylov steps each.
Also shift the Hamiltonian in-place `H → H - E0`.