### PR TITLE
perf: use tridiagonal matrix

### DIFF
--- a/src/update_hybridization_function.jl
+++ b/src/update_hybridization_function.jl
@@ -16,7 +16,6 @@ function update_hybridization_function(
     Δ0::PolesSum{R,R}, μ::R, Σ_H::R, Σ::PolesSum{R,R}
 ) where {R<:Real}
     Σ = remove_zero_weight(Σ)
-    foo = Matrix{R}(Array(Σ)) # create once for speed
 
     n = length(Σ) + 1
     n_tot = length(Δ0) * n
@@ -24,14 +23,21 @@ function update_hybridization_function(
     wgt_new = Vector{R}(undef, n_tot)
     result = PolesSum(loc_new, wgt_new)
 
-    # diagonalization for each pole in Δ0
+    # Create tridiagonal matrix `T` using Householder transformations.
+    # These do not touch the (1,1) element of the original matrix,
+    # making it perfect for our use case.
+    h = hessenberg!(Array(Σ)) # don't give symmetric information on purpose
+    T = SymTridiagonal(diag(h.H), diag(h.H, -1)) # diagonal and first lower diagonal
+
+    # Update the (1,1) element for each pole in Δ0 and diagonalize `T`.
     Threads.@threads for i in eachindex(Δ0)
         idx_low = 1 + n * (i - 1)
         idx_high = idx_low + n - 1
-        bar = copy(foo)
+        bar = copy(T)
         bar[1, 1] = Σ_H - μ + locations(Δ0)[i]
-        loc_new[idx_low:idx_high], T = eigen!(Symmetric(bar))
-        wgt_new[idx_low:idx_high] = weight(Δ0, i) .* abs2.(view(T, 1, :)) # multiply new weights with original
+        loc_new[idx_low:idx_high], U = eigen!(bar)
+        U = h.Q * U # transform back
+        wgt_new[idx_low:idx_high] = weight(Δ0, i) .* abs2.(view(U, 1, :)) # multiply new weights with original
     end
 
     sort!(result)


### PR DESCRIPTION
Instead of full diagonalization, create a tridiagonal matrix once and diagonalize a (1,1) element changed version of it.