### PR TITLE
feat!: add regularization for quasiparticle weight calculation

### DIFF
--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -146,6 +146,7 @@ xlims!(ax, first(W), last(W))
 # ### Self-energy
 # Here, we use the improved symmetric estimator[^Kugler2022] ``Σ^\mathrm{IFG}``.
 Σ = self_energy_IFG(C)
+Σ = PolesSum(Σ, 1, 1)
 sigma = evaluate_gaussian(Σ, W, σ)
 f = Figure();
 ax = Axis(f[1, 1]; xlabel = L"ω/D", ylabel = L"Σ(ω)/D")
@@ -170,7 +171,7 @@ xlims!(ax, first(W), last(W))
 # Due to poles at $ϵ_i≈0$ this will diverge,
 # and poles with small weight need to be ignored.
 # This is controlled by the second parameter.
-quasiparticle_weight(Σ, sqrt(eps()))
+quasiparticle_weight(Σ; tol = sqrt(eps()))
 
 # ### Update hybridization
 # At the end of each DMFT step, we have to update the hybridization function

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -206,35 +206,34 @@ function moments(f::AbstractVector{<:Complex}, W::AbstractVector{<:Real}, ns)
     return map(i -> moment(f, W, i), ns)
 end
 
-function _derivative(P::PolesSum, ω::R, tol::Real = 0) where {R <: Real}
-    tol >= 0 || throw(ArgumentError("tol must be semipositive"))
-
-    result = zero(promote_type(eltype(P), R))
-    for i in eachindex(P)
-        weight(P, i) < tol && continue
-        result -= weight(P, i) / (ω - locations(P)[i])^2
-    end
-    return result
-end
-
 """
-    quasiparticle_weight(Σ::PolesSum, tol::Real=0)
+    quasiparticle_weight(Σ::PolesSum; tol::Real = 0, λ::Real = 0)
 
 Obtain the quasiparticle weight on the real axis.
 
 ```math
-Z = \\left(1 - \\frac{∂\\mathrm{Re}~Σ(0)}{∂ω}\\right)^{-1}
+\\begin{aligned}
+Z &= \\left(1 - \\frac{∂\\mathrm{Re}~Σ(0)}{∂ω}\\right)^{-1} \\\\
+  &= \\left(1 - \\sum_i w_i \\frac{∂}{∂ω}\\left.\\frac{1}{ω-a_i}\\right|_{ω=0}\\right)^{-1} \\\\
+  &= \\left(1 + \\sum_{w_i ≥ \\mathrm{tol}} w_i\\frac{1}{a_i^2 + λ^2}\\right)^{-1} \\\\
+\\end{aligned}
 ```
 
-Skip all weights `< tol`.
+Skip all weights ``w_i< \\mathrm{tol}``.
+The variable ``λ`` serves as a regularization parameter.
 
 See also [`quasiparticle_weight_gaussian`](@ref).
 """
-function quasiparticle_weight(Σ::PolesSum, tol::Real = 0)
+function quasiparticle_weight(Σ::PolesSum; tol::Real = 0, λ::Real = 0)
     tol >= 0 || throw(ArgumentError("tol must be semipositive"))
+    λ >= 0 || throw(ArgumentError("λ must be semipositive"))
 
-    foo = _derivative(Σ, zero(eltype(Σ)), tol)
-    return inv(1 - foo)
+    deriv = zero(Float64)
+    for i in eachindex(Σ)
+        weight(Σ, i) < tol && continue
+        deriv += weight(Σ, i) / (locations(Σ)[i]^2 + λ^2)
+    end
+    return inv(1 + deriv)
 end
 
 """

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -92,8 +92,10 @@ using Test
         # pole
         Σ = PolesSum([-0.25, -0.01, 0.5], [1.0, 2.0, 3.0])
         @test quasiparticle_weight(Σ) == inv(20029)
-        @test quasiparticle_weight(Σ, 1.0) == inv(20029)
-        @test quasiparticle_weight(Σ, 1.1) == inv(20013)
+        @test quasiparticle_weight(Σ; tol = 1.0) == inv(20029)
+        @test quasiparticle_weight(Σ; tol = 1.1) == inv(20013)
+        @test quasiparticle_weight(Σ; λ = 1.0e-2) ≈ inv(10028.9696428138) atol = 10 * eps()
+        @test quasiparticle_weight(Σ; tol = 1.1, λ = 1.0e-2) ≈ inv(10012.995201919231) atol = 10 * eps()
 
         # grid
         W = [-0.5, -0.25, 0.0, 0.25, 0.5]


### PR DESCRIPTION
Parameter `lambda` to control spurious poles close to Fermi-energy.