### PR TITLE
build: use `[workspace]` section

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,7 +6,9 @@ Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 RAS_DMFT = "a6c836f4-75b2-4167-a711-17703ee59b5f"
 
 [compat]
-Changelog = "1"
-Documenter = "1"
-Literate = "2"
-julia = "1"
+Changelog = "1.1.0"
+Documenter = "1.17.0"
+Fermions = "0.12.0"
+Literate = "2.21.0"
+RAS_DMFT = "0.10.0"
+julia = "1.12.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Changelog
-using RAS_DMFT
 using Documenter
 using Literate
+using RAS_DMFT
 
 DocMeta.setdocmeta!(RAS_DMFT, :DocTestSetup, :(using RAS_DMFT); recursive = true)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,26 +1,22 @@
-name = "RAS_DMFT"
-uuid = "a6c836f4-75b2-4167-a711-17703ee59b5f"
-version = "0.10.0"
-authors = ["Frank Ebel <frank.ebel@tuwien.ac.at> and contributors"]
-
-[workspace]
-projects = ["docs", "test"]
-
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Fermions = "5323e9fa-b7db-5fd3-973f-d33ddadd0ada"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+RAS_DMFT = "a6c836f4-75b2-4167-a711-17703ee59b5f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.8.16"
 Distributions = "0.25.100 - 0.25.127"
 Fermions = "0.12.0"
 HDF5 = "0.17.2"
 LinearAlgebra = "1.12.0"
+Logging = "1.11.0"
+RAS_DMFT = "0.10.0"
 SparseArrays = "1.12.0"
-SpecialFunctions = "2.7.2"
-Statistics = "1.11.1"
+Test = "1.11.0"
 julia = "1.12.6"


### PR DESCRIPTION
Since Julia 1.12, one can use the `[workspace]` section https://pkgdocs.julialang.org/v1/toml-files/#The-%5Bworkspace%5D-section

Also pin lowest required version of all packages to major.minor.patch.