### PR TITLE
explicitly specify matrix representation for given pole representation

### DIFF
--- a/src/ED.jl
+++ b/src/ED.jl
@@ -16,7 +16,7 @@ Solve AIM in exact diagonalization.
 """
 function solve_impurity_ed(Δ::PolesSum, H_int::Operator, ϵ_imp::Real)
     # Get Hamiltonian
-    H_nat, n_occ = to_natural_orbitals(Array(Δ))
+    H_nat, n_occ = to_natural_orbitals(arrowhead_matrix(Δ))
     n_sites = size(H_nat, 1)
     fs = FockSpace(Orbitals(n_sites), FermionicSpin(1 // 2))
     H = natural_orbital_operator(

--- a/src/Poles/abstractpolescontinuedfraction.jl
+++ b/src/Poles/abstractpolescontinuedfraction.jl
@@ -15,3 +15,20 @@ amplitudes(P::AbstractPolesContinuedFraction) = P.amplitudes
 Return the scale of `P`.
 """
 scale(P::AbstractPolesContinuedFraction) = P.scale
+
+"""
+    tridiagonal_matrix(P::AbstractPolesSum)
+
+Calculate the (block) tridiagonal representation of `P`
+
+```math
+\\begin{pmatrix}
+A_1 & B_1 &     &         &         \\\\
+B_1 & A_2 & B_2 &         &         \\\\
+    & B_2 & ⋱   &  ⋱      &         \\\\
+    &     & ⋱   &  ⋱      & B_{N-1} \\\\
+    &     &     & B_{N-1} & A_N
+\\end{pmatrix} .
+```
+"""
+function tridiagonal_matrix end

--- a/src/Poles/abstractpolessum.jl
+++ b/src/Poles/abstractpolessum.jl
@@ -8,6 +8,16 @@ abstract type AbstractPolesSum <: AbstractPoles end
 amplitudes(P::AbstractPolesSum, args...; kwargs...) = map(i -> amplitude(P, i, args...; kwargs...), eachindex(P))
 
 """
+    anderson_matrix(P::AbstractPolesSum)
+
+Calculate scaling factor ``B_0`` and Anderson matrix ``H_\\mathrm{A}``
+given a sum of poles `P`.
+
+Reference: [DOI](https://doi.org/10.48550/arXiv.2605.04974), appendix A3d
+"""
+function anderson_matrix end
+
+"""
     arrowhead_matrix(P::AbstractPolesSum, args...; kwargs...)
 
 Calculate the (block) arrowhead matrix representation of

--- a/src/Poles/abstractpolessum.jl
+++ b/src/Poles/abstractpolessum.jl
@@ -8,6 +8,30 @@ abstract type AbstractPolesSum <: AbstractPoles end
 amplitudes(P::AbstractPolesSum, args...; kwargs...) = map(i -> amplitude(P, i, args...; kwargs...), eachindex(P))
 
 """
+    arrowhead_matrix(P::AbstractPolesSum, args...; kwargs...)
+
+Calculate the (block) arrowhead matrix representation of
+
+```math
+\\frac{1}{z - \\mathbb{0} - P(z)} .
+```
+
+See also [`amplitude`](@ref) for details of `args...` and `kwargs...`.
+
+```jldoctest
+julia> P = PolesSum(1:2, [4, 9])
+PolesSum{Int64, Int64} with 2 poles
+
+julia> arrowhead_matrix(P)
+3×3 Matrix{Float64}:
+ 0.0  2.0  3.0
+ 2.0  1.0  0.0
+ 3.0  0.0  2.0
+```
+"""
+function arrowhead_matrix end
+
+"""
     filling(P::AbstractPolesSum, μ::Real=0)
 
 Calculate

--- a/src/Poles/conversion.jl
+++ b/src/Poles/conversion.jl
@@ -1,16 +1,6 @@
 # Conversion between different representations.
 
-"""
-    anderson_matrix(P::PolesSum)
-    anderson_matrix(P::PolesSumBlock)
-
-Calculate scaling factor ``B_0`` and Anderson matrix ``H_\\mathrm{A}``
-given a sum of poles.
-
-Reference: https://doi.org/10.48550/arXiv.2605.04974, appendix A3d
-"""
 function anderson_matrix(P::PolesSum)
-    T = eltype(P) <: Real ? Float64 : ComplexF64
     N = length(P)
 
     return _with_blas_threads(Threads.nthreads()) do
@@ -44,13 +34,12 @@ function anderson_matrix(P::PolesSum)
 end
 
 function anderson_matrix(P::PolesSumBlock)
-    T = eltype(P) <: Real ? Float64 : ComplexF64
     N = length(P)
-    n = size(P, 1) # block size
+    n_b = size(P, 1) # block size
 
     return _with_blas_threads(Threads.nthreads()) do
-        H_LP = Diagonal(repeat(locations(P); inner = n))
-        V::Matrix{T} = vcat(amplitudes(P)...)
+        H_LP = Diagonal(repeat(locations(P); inner = n_b))
+        V = vcat(amplitudes(P)...)
         R_a, B_0 = RAS_DMFT._orthonormalize_SVD(V)
         RAS_DMFT._orthonormalize_GramSchmidt!(R_a) # numerical instability
         RAS_DMFT._orthonormalize_GramSchmidt!(R_a) # numerical instability
@@ -63,17 +52,17 @@ function anderson_matrix(P::PolesSumBlock)
         # (1 0   ) * ( h11 h12 ) * ( 1 0  ) = ( h11 h12*U2 )
         # (0 U2' ) * ( h21 h22 )   ( 0 U2 )   ( U2'*h21  d )
         # with d diagonal
-        F = eigen!(Hermitian(h[(n + 1):end, (n + 1):end]))
+        F = eigen!(Hermitian(h[(n_b + 1):end, (n_b + 1):end]))
         # Anderson matrix
         H_A = zero(h)
-        H_A[1:n, 1:n] .= @view h[1:n, 1:n]
-        for i in (n + 1):(N * n)
-            @inline H_A[i, i] = F.values[i - n]
+        H_A[1:n_b, 1:n_b] .= @view h[1:n_b, 1:n_b]
+        for i in (n_b + 1):(N * n_b)
+            @inline H_A[i, i] = F.values[i - n_b]
         end
-        h21 = @view h[(n + 1):end, 1:n]
-        H_A21 = @view H_A[(n + 1):end, 1:n]
+        h21 = @view h[(n_b + 1):end, 1:n_b]
+        H_A21 = @view H_A[(n_b + 1):end, 1:n_b]
         mul!(H_A21, F.vectors', h21)
-        H_A12 = @view H_A[1:n, (n + 1):end] # H_A12
+        H_A12 = @view H_A[1:n_b, (n_b + 1):end] # H_A12
         adjoint!(H_A12, H_A21)
 
         B_0, Hermitian(H_A)

--- a/src/Poles/conversion.jl
+++ b/src/Poles/conversion.jl
@@ -129,8 +129,7 @@ end
 # block form
 
 function PolesSumBlock(P::PolesContinuedFractionBlock)
-    T = eltype(P) <: Real ? Float64 : ComplexF64 # use double precision
-    F = eigen!(hermitianpart!(Matrix{T}(Array(P))))
+    F = eigen!(Hermitian(tridiagonal_matrix(P)))
     amp = scale(P) * view(F.vectors, 1:size(P, 1), :)
     result = PolesSumBlock(F.values, amp)
     remove_zero_weight!(result)

--- a/src/Poles/polescontinuedfraction.jl
+++ b/src/Poles/polescontinuedfraction.jl
@@ -56,14 +56,11 @@ function evaluate_lorentzian(P::PolesContinuedFraction, ω::Real, δ::Real)
     return result
 end
 
+tridiagonal_matrix(P::PolesContinuedFraction) = Matrix(SymTridiagonal(P))
+
 weight(P::PolesContinuedFraction, i::Integer) = abs2(amplitudes(P)[i])
 
 weights(P::PolesContinuedFraction) = abs2.(amplitudes(P))
-
-function Core.Array(P::PolesContinuedFraction)
-    # lose information about scale
-    return Array(SymTridiagonal(P))
-end
 
 Base.eltype(::Type{<:PolesContinuedFraction{A, B}}) where {A, B} = promote_type(A, B)
 

--- a/src/Poles/polescontinuedfractionblock.jl
+++ b/src/Poles/polescontinuedfractionblock.jl
@@ -86,11 +86,11 @@ function evaluate_lorentzian(P::PolesContinuedFractionBlock, ω::Real, δ::Real)
     return result
 end
 
-function Core.Array(P::PolesContinuedFractionBlock)
+function tridiagonal_matrix(P::PolesContinuedFractionBlock)
     n1 = length(P)
     n2 = size(P, 1)
     n = n1 * n2
-    result = zeros(eltype(P), n, n)
+    result = zeros(eltype(P), n, n)::Matrix{eltype(P)}
     for i in 1:(n1 - 1)
         i1 = 1 + (i - 1) * n2
         i2 = i * n2

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -69,6 +69,21 @@ end
 
 amplitude(P::PolesSum{<:Any, <:Real}, i::Integer) = sqrt(weight(P, i))
 
+function arrowhead_matrix(P::PolesSum)
+    amps = amplitudes(P)
+    T = promote_type(eltype(P), eltype(amps))
+    n = length(P) + 1
+    result = zeros(T, n, n)::Matrix{T}
+
+    for i in eachindex(P)
+        result[i + 1, i + 1] = location(P, i)
+    end
+    result[1, 2:end] .= amps
+    result[2:end, 1] .= amps
+
+    return result
+end
+
 function evaluate_gaussian(P::PolesSum, ω::Real, σ::Real)
     real = zero(ω)
     imag = zero(ω)
@@ -307,14 +322,6 @@ function spectral_function_loggaussian(P::PolesSum, ω::AbstractVector{<:Real}, 
 end
 
 weight(P::PolesSum, i::Integer) = weights(P)[i]
-
-function Core.Array(P::PolesSum)
-    T = eltype(P)
-    result = Matrix{T}(Diagonal([0; locations(P)]))
-    result[1, 2:end] .= amplitudes(P)
-    result[2:end, 1] .= amplitudes(P)
-    return result
-end
 
 function Base.:+(A::PolesSum, B::PolesSum)
     result = PolesSum([locations(A); locations(B)], [weights(A); weights(B)])

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -183,9 +183,6 @@ end
 
 PolesSumBlock{A, B}(P::PolesSumBlock) where {A, B} = convert(PolesSumBlock{A, B}, P)
 
-# General Julia code does not know about semipositive eigenvalues
-# and gives eltype as union of Float64 and ComplexF64.
-# Therefore, decompose by hand and apply square root in-place.
 function amplitude(P::PolesSumBlock, i::Integer, tol_amp::Real = 0; thin::Bool = false)
     tol_amp >= 0 || throw(DomainError(tol_amp, "negative amplitude"))
 
@@ -193,6 +190,9 @@ function amplitude(P::PolesSumBlock, i::Integer, tol_amp::Real = 0; thin::Bool =
     F = eigen(w)
     map!(i -> i > tol_amp^2 ? sqrt(i) : zero(i), F.values) # set small amplitudes to zero
     if !thin
+        # General Julia code does not know about semipositive eigenvalues
+        # and gives eltype as union of Float64 and ComplexF64.
+        # Therefore, decompose by hand and apply square root in-place.
         result = F.vectors * Diagonal(F.values) * F.vectors'
         hermitianpart!(result)
     else
@@ -206,6 +206,28 @@ function amplitude(P::PolesSumBlock, i::Integer, tol_amp::Real = 0; thin::Bool =
             j += 1
         end
     end
+    return result
+end
+
+function arrowhead_matrix(P::PolesSumBlock, args...; kwargs...)
+    amps = amplitudes(P, args...; kwargs...)
+    T = promote_type(eltype(P), eltype(eltype((amps))))
+    n_b = size(P, 1)
+    dim = n_b + sum(amp -> size(amp, 2), amps)
+    result = zeros(T, dim, dim)::Matrix{T}
+
+    idx = n_b
+    @inbounds for i in eachindex(P)
+        amp = amps[i]
+        r = size(amp, 2) # rank of amplitude matrix
+        result[1:n_b, (idx + 1):(idx + r)] = amp
+        result[(idx + 1):(idx + r), 1:n_b] = amp'
+        for j in (idx + 1):(idx + r)
+            result[j, j] = location(P, i)
+        end
+        idx += r
+    end
+
     return result
 end
 
@@ -344,24 +366,6 @@ end
 
 function moment(P::PolesSumBlock, n::Int = 0)
     return sum(i -> i[1]^n * i[2], zip(locations(P), weights(P)))
-end
-
-function Core.Array(P::PolesSumBlock)
-    T = eltype(P) <: Real ? Float64 : ComplexF64
-    N = length(P)
-    n = size(P, 1)
-    result = zeros(T, (N + 1) * n, (N + 1) * n)
-    A = locations(P)
-    result[1:n, 1:n] = zeros(T, n, n)
-    for i in 2:(N + 1)
-        i1 = (i - 1) * n + 1
-        i2 = i * n
-        B = amplitude(P, i - 1)
-        result[1:n, i1:i2] = B # first block row
-        result[i1:i2, 1:n] = B # first block column
-        map(j -> result[j, j] = A[i - 1], i1:i2) # main diagonal
-    end
-    return result
 end
 
 function Base.:+(A::PolesSumBlock{<:Any, TA}, B::PolesSumBlock{<:Any, TB}) where {TA, TB}

--- a/src/RAS_DMFT.jl
+++ b/src/RAS_DMFT.jl
@@ -91,6 +91,7 @@ export
     temperature_kondo,
     to_grid,
     to_natural_orbitals,
+    tridiagonal_matrix,
     update_hybridization_function,
     weight,
     weights,

--- a/src/RAS_DMFT.jl
+++ b/src/RAS_DMFT.jl
@@ -27,6 +27,7 @@ export
     amplitude,
     amplitudes,
     anderson_matrix,
+    arrowhead_matrix,
     block_lanczos,
     block_lanczos_full_ortho,
     correlator,

--- a/src/self_energy.jl
+++ b/src/self_energy.jl
@@ -98,7 +98,7 @@ function self_energy_IFG(C::PolesSumBlock, block::Int = 1)
     end
 
     # diagonalize
-    H = Array(P)
+    H = arrowhead_matrix(P)
     H[1:(n ÷ 2), 1:(n ÷ 2)] = A1
     F = eigen!(H)
     loc = F.values

--- a/src/update_hybridization_function.jl
+++ b/src/update_hybridization_function.jl
@@ -25,7 +25,7 @@ function update_hybridization_function(
     # Create tridiagonal matrix `T` using Householder transformations.
     # These do not touch the (1,1) element of the original matrix,
     # making it perfect for our use case.
-    h = hessenberg!(Array(Σ)) # don't give symmetric information on purpose
+    h = hessenberg!(arrowhead_matrix(Σ)) # don't give symmetric information on purpose
     T = SymTridiagonal(diag(h.H), diag(h.H, -1)) # diagonal and first lower diagonal
 
     # Update the (1,1) element for each pole in Δ0 and diagonalize `T`.

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -35,7 +35,7 @@ Return Hamiltonian, ground state energy, and ground state.
 function init_system(
         Δ::PolesSum, H_int::Operator, ϵ_imp::Real, L_v::Int, L_c::Int, p::Int, var::Real
     )
-    arr = Array(Δ)
+    arr = arrowhead_matrix(Δ)
     n_sites = size(arr, 1)
     H_nat, n_occ = to_natural_orbitals(arr)
     n_bit, V_v, V_c = get_CI_parameters(n_sites, n_occ, L_c, L_v)

--- a/test/Poles/conversion.jl
+++ b/test/Poles/conversion.jl
@@ -112,7 +112,7 @@ using Test
         P = PolesSumBlock([1, 2], [[1.0 0; 0 1], [0 0; 0 1]])
         PCF = PolesContinuedFractionBlock(P)
         @test scale(PCF) == Diagonal([1, sqrt(2)])
-        @test norm(Array(PCF) - [1 0 0 0; 0 1.5 0 0.5; 0 0 0 0; 0 0.5 0 1.5]) < 10 * eps()
+        @test norm(tridiagonal_matrix(PCF) - [1 0 0 0; 0 1.5 0 0.5; 0 0 0 0; 0 0.5 0 1.5]) < 10 * eps()
         PS = PolesSumBlock(PCF)
         merge_degenerate_poles!(PS, 5 * eps())
         @test norm(locations(PS) - [1, 2]) < 10 * eps()

--- a/test/Poles/conversion.jl
+++ b/test/Poles/conversion.jl
@@ -15,6 +15,7 @@ using Test
                 sqrt(0.4) 0.0 sqrt(0.2)
             ]
         ) < 10 * eps()
+
         # block
         P = PolesSumBlock(
             [-1.0, 0, 1],
@@ -32,6 +33,64 @@ using Test
         @test norm(locations(P_new) - locations(P)) < 20 * eps()
         @test all(<(50 * eps()), norm.(weights(P_new) .- weights(P))) # norm of each weight difference
     end # Anderson matrix
+
+    @testset "arrowhead matrix" begin
+        # scalar
+        loc = 1:5
+        amp = 6:10
+        P = PolesSum(loc, abs2.(amp))
+        ma = arrowhead_matrix(P)
+        @inferred arrowhead_matrix(P)
+        @test ma isa Matrix{Float64}
+        @test ma == [
+            0 6 7 8 9 10
+            6 1 0 0 0 0
+            7 0 2 0 0 0
+            8 0 0 3 0 0
+            9 0 0 0 4 0
+            10 0 0 0 0 5
+        ]
+        # pole with zero weight
+        loc = 1:5
+        amp = [6, 7, 0, 9, 0]
+        P = PolesSum(loc, abs2.(amp))
+        ma = arrowhead_matrix(P)
+        @test ma == [
+            0 6 7 0 9 0
+            6 1 0 0 0 0
+            7 0 2 0 0 0
+            0 0 0 3 0 0
+            9 0 0 0 4 0
+            0 0 0 0 0 5
+        ]
+
+        # block
+        locs = 1:2
+        amps = [
+            rand(ComplexF64, 4, 1),
+            rand(ComplexF64, 4, 2),
+        ]
+        wgts = map(amp -> amp * amp', amps)
+        P = PolesSumBlock(locs, wgts)
+        ma = arrowhead_matrix(P)
+        @inferred arrowhead_matrix(P)
+        @test ishermitian(ma)
+        @test iszero(@view ma[1:4, 1:4])
+        amp1 = @view ma[1:4, 5:8]
+        @test norm(wgts[1] - amp1 * amp1') < 100 * eps()
+        amp2 = @view ma[1:4, 9:12]
+        @test norm(wgts[2] - amp2 * amp2') < 100 * eps()
+        @test view(ma, 5:12, 5:12) == Diagonal([1, 1, 1, 1, 2, 2, 2, 2])
+        # thin rectangular amplitudes
+        ma = arrowhead_matrix(P, 10 * sqrt(eps()); thin = true)
+        @test ishermitian(ma)
+        @test iszero(@view ma[1:4, 1:4])
+        amp1 = @view ma[1:4, 5]
+        @test norm(wgts[1] - amp1 * amp1') < 100 * eps()
+        amp2 = @view ma[1:4, 6:7]
+        @test norm(wgts[2] - amp2 * amp2') < 100 * eps()
+        @test view(ma, 5:7, 5:7) == Diagonal([1, 2, 2])
+    end # arrowhead matrix
 
     @testset "scalar" begin
         P = PolesContinuedFraction(5:10, 0.1:0.1:0.5, 0.25)

--- a/test/Poles/conversion.jl
+++ b/test/Poles/conversion.jl
@@ -25,10 +25,10 @@ using Test
                 [1 0.1; 0.1 0.5 ],
             ]
         )
-        B0, HA = anderson_matrix(P)
-        @test norm(B0 * B0 - sum(weights(P))) < 50 * eps()
-        F = eigen(HA)
-        B = B0 * F.vectors[1:2, :]
+        B_0, H_A = anderson_matrix(P)
+        @test norm(B_0 * B_0 - sum(weights(P))) < 50 * eps()
+        F = eigen(H_A)
+        B = B_0 * F.vectors[1:2, :]
         P_new = PolesSumBlock(copy(F.values), B, 50 * eps())
         @test norm(locations(P_new) - locations(P)) < 20 * eps()
         @test all(<(50 * eps()), norm.(weights(P_new) .- weights(P))) # norm of each weight difference

--- a/test/Poles/polescontinuedfraction.jl
+++ b/test/Poles/polescontinuedfraction.jl
@@ -85,6 +85,16 @@ using Test
             @test scale(P) === scl
         end # scale
 
+        @testset "tridiagonal_matrix" begin
+            loc = 1:3
+            amp = 4:5
+            scl = 2
+            P = PolesContinuedFraction(loc, amp, scl)
+            @test tridiagonal_matrix(P) == [1 4 0; 4 2 5; 0 5 3]
+            P = PolesContinuedFraction(loc, amp)
+            @test tridiagonal_matrix(P) == [1 4 0; 4 2 5; 0 5 3]
+        end # tridiagonal_matrix
+
         @testset "weight" begin
             P = PolesContinuedFraction([-1.0, 0.0, 0.5], [0.25, 1.5])
             @test_throws BoundsError weight(P, 0)
@@ -98,18 +108,6 @@ using Test
             @test weights(P) == [0.0625, 2.25]
         end # weights
     end # custom functions
-
-    @testset "Core" begin
-        @testset "Array" begin
-            loc = 1:3
-            amp = 4:5
-            scl = 2
-            P = PolesContinuedFraction(loc, amp, scl)
-            @test Array(P) == [1 4 0; 4 2 5; 0 5 3]
-            P = PolesContinuedFraction(loc, amp)
-            @test Array(P) == [1 4 0; 4 2 5; 0 5 3]
-        end # Array
-    end # Core
 
     @testset "Base" begin
         @testset "eltype" begin

--- a/test/Poles/polescontinuedfractionblock.jl
+++ b/test/Poles/polescontinuedfractionblock.jl
@@ -101,6 +101,30 @@ using Test
             @test scale(P) === scl
         end # scale
 
+        @testset "tridiagonal_matrix" begin
+            loc = [[1 2; 2 3], [4 5; 5 6], [7 8; 8 9]]
+            amp = [[10 11; 11 12], [13 14; 14 15]]
+            scl = [16 17; 17 18]
+            P = PolesContinuedFractionBlock(loc, amp, scl)
+            @test tridiagonal_matrix(P) == [
+                1  2  10 11 0  0
+                2  3  11 12 0  0
+                10 11 4  5  13 14
+                11 12 5  6  14 15
+                0  0  13 14 7  8
+                0  0  14 15 8  9
+            ]
+            P = PolesContinuedFractionBlock(loc, amp)
+            @test tridiagonal_matrix(P) == [
+                1  2  10 11 0  0
+                2  3  11 12 0  0
+                10 11 4  5  13 14
+                11 12 5  6  14 15
+                0  0  13 14 7  8
+                0  0  14 15 8  9
+            ]
+        end # tridiagonal_matrix
+
         @testset "weight" begin
             loc = [[1 2; 2 3], [4 5; 5 6]]
             amp = [[7 8; 8 9]]
@@ -117,32 +141,6 @@ using Test
             @test_throws MethodError weights(P)
         end # weights
     end # custom functions
-
-    @testset "Core" begin
-        @testset "Array" begin
-            loc = [[1 2; 2 3], [4 5; 5 6], [7 8; 8 9]]
-            amp = [[10 11; 11 12], [13 14; 14 15]]
-            scl = [16 17; 17 18]
-            P = PolesContinuedFractionBlock(loc, amp, scl)
-            @test Array(P) == [
-                1 2 10 11 0 0
-                2 3 11 12 0 0
-                10 11 4 5 13 14
-                11 12 5 6 14 15
-                0 0 13 14 7 8
-                0 0 14 15 8 9
-            ]
-            P = PolesContinuedFractionBlock(loc, amp)
-            @test Array(P) == [
-                1 2 10 11 0 0
-                2 3 11 12 0 0
-                10 11 4 5 13 14
-                11 12 5 6 14 15
-                0 0 13 14 7 8
-                0 0 14 15 8 9
-            ]
-        end # Array
-    end # Core
 
     @testset "Base" begin
         @testset "eltype" begin

--- a/test/Poles/polessum.jl
+++ b/test/Poles/polessum.jl
@@ -386,47 +386,6 @@ using Test
         end # weights
     end # custom functions
 
-    @testset "Core" begin
-        @testset "Array" begin
-            loc = 1:5
-            amp = 6:10
-            P = PolesSum(loc, abs2.(amp))
-            m = Array(P)
-            @test typeof(m) === Matrix{Int}
-            @test m == [
-                0 6 7 8 9 10
-                6 1 0 0 0 0
-                7 0 2 0 0 0
-                8 0 0 3 0 0
-                9 0 0 0 4 0
-                10 0 0 0 0 5
-            ]
-            # poles with zero weight
-            loc = 1:5
-            amp = [6, 7, 0, 9, 0]
-            P = PolesSum(loc, abs2.(amp))
-            m = Array(P)
-            @test m == [
-                0 6 7 0 9 0
-                6 1 0 0 0 0
-                7 0 2 0 0 0
-                0 0 0 3 0 0
-                9 0 0 0 4 0
-                0 0 0 0 0 5
-            ]
-            # correct promotion
-            loc = 1:2
-            amp = [1.1, 5.5]
-            P = PolesSum(loc, abs2.(amp))
-            m = Array(P)
-            @test m == [
-                0 1.1 5.5
-                1.1 1 0
-                5.5 0 2
-            ]
-        end # Array
-    end # Core
-
     @testset "Base" begin
         @testset "+" begin
             # addition must sort resulting poles

--- a/test/Poles/polessumblock.jl
+++ b/test/Poles/polessumblock.jl
@@ -298,30 +298,6 @@ using Test
         end # weights
     end # custom functions
 
-    @testset "Core" begin
-        @testset "Array" begin
-            A = [-7, 9]
-            B1 = [4.0 3; 3 4]
-            W1 = B1 * B1'
-            B2 = [5 0; 0 1]
-            W2 = B2 * B2'
-            P = PolesSumBlock(A, [W1, W2])
-            m = Array(P)
-            @test typeof(m) == Matrix{Float64}
-            @test norm(
-                m -
-                    [
-                    0 0  4  3 5 0
-                    0 0  3  4 0 1
-                    4 3 -7  0 0 0
-                    3 4  0 -7 0 0
-                    5 0  0  0 9 0
-                    0 1  0  0 0 9
-                ]
-            ) < 50 * eps()
-        end # Array
-    end # Core
-
     @testset "Base" begin
         @testset "+" begin
             # addition must sort and merge poles

--- a/test/natural_orbitals.jl
+++ b/test/natural_orbitals.jl
@@ -8,7 +8,7 @@ using Test
 @testset "natural orbitals" begin
     @testset "matrix transformation" begin
         Δ = hybridization_function_bethe_simple(11)
-        m = Array(Δ)
+        m = arrowhead_matrix(Δ)
         H, n_occ = to_natural_orbitals(m)
 
         @test n_occ === 6
@@ -32,7 +32,7 @@ using Test
         ] atol = 2.0e-13
 
         Δ = hybridization_function_bethe_simple(301)
-        m = Array(Δ)
+        m = arrowhead_matrix(Δ)
         H, n_occ = to_natural_orbitals(m)
         @test n_occ === 151
         E = eigvals(H)
@@ -49,7 +49,7 @@ using Test
 
         # sites with zero hybridization, Löwdin must not return negative eigenvalues
         Δ = hybridization_function_bethe_grid(range(-2, 2; length = 31))
-        to_natural_orbitals(Array(Δ))
+        to_natural_orbitals(arrowhead_matrix(Δ))
     end # matrix transformation
 
     @testset "operator" begin
@@ -357,7 +357,7 @@ using Test
             n = occupations(fs)
             H_int = U1 * n[1, -1 // 2] * n[1, 1 // 2]
             Δ = hybridization_function_bethe_simple(11)
-            H_nat, n_occ1 = to_natural_orbitals(Array(Δ))
+            H_nat, n_occ1 = to_natural_orbitals(arrowhead_matrix(Δ))
             H = natural_orbital_ci_operator(H_nat, H_int, -μ1, fs, n_occ1, 2, 2, 2)
             @test length(H.opbit.terms) == 1 + 2 * 6 + 4 * 7
             @test length(H.opmix) == 96 # didn't calculate myself
@@ -442,7 +442,7 @@ using Test
 
         # Single particle part of the Hamiltonian as a Matrix H0.
         Δ = hybridization_function_bethe_simple(n_bath)
-        H_nat, n_occ = to_natural_orbitals(Array(Δ))
+        H_nat, n_occ = to_natural_orbitals(arrowhead_matrix(Δ))
         n_emp = n_sites - n_occ
         n_v_vector = n_occ - 1 - n_v_bit
         n_c_vector = n_emp - 1 - n_c_bit

--- a/test/wavefunctions.jl
+++ b/test/wavefunctions.jl
@@ -56,7 +56,7 @@ using Test
         n_sites = 1 + n_bath
 
         Δ = hybridization_function_bethe_simple(n_bath)
-        H_nat, n_occ = to_natural_orbitals(Array(Δ))
+        H_nat, n_occ = to_natural_orbitals(arrowhead_matrix(Δ))
         n_bit, V_v, V_c = get_CI_parameters(n_sites, n_occ, L_c, L_v)
 
         # CIWavefunction


### PR DESCRIPTION
Explicitly call `anderson_matrix`, `arrowhead_matrix`, or `tridiagonal_matrix`.