### PR TITLE
refactor(Poles): change underlying matrix for weights

### DIFF
--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -1,24 +1,26 @@
 """
-    PolesSumBlock{A<:Real,B<:Number} <: AbstractPolesSum
+    PolesSumBlock{A <: Real, B <: Number} <: AbstractPolesSum
 
 Representation of block of poles on the real axis with locations ``a_i`` of type `A`
-and weights ``W_i`` of type `Hermitian{B, Matrix{B}}` (``W_i^† = W_i``).
+and weights ``W_i`` of type `Matrix{B}`.
 
 ```math
 P(ω) = ∑_i \\frac{W_i}{ω-a_i}.
 ```
 
 For ``W_i`` to be physical,
-it needs to be positive semidefinite ``W_i ⪰ 0``.
+it needs to be Hermitian (``W_i^† = W_i``)
+and positive semidefinite ``W_i ⪰ 0``.
 
 For a scalar variant see [`PolesSum`](@ref).
 """
 struct PolesSumBlock{A <: Real, B <: Number} <: AbstractPolesSum
     locations::Vector{A}
-    weights::Vector{Hermitian{B, Matrix{B}}}
+    weights::Vector{Matrix{B}}
 
     function PolesSumBlock{A, B}(locations, weights) where {A, B}
         length(locations) == length(weights) || throw(DimensionMismatch("length mismatch"))
+        all(ishermitian, weights)::Bool || throw(ArgumentError("weights are not hermitian"))
         allequal(size, weights)::Bool ||
             throw(DimensionMismatch("weights do not have matching size"))
         result = new{A, B}(locations, weights)
@@ -33,9 +35,6 @@ end
 
 Create a new instance of [`PolesSumBlock`](@ref) by supplying locations `loc`
 and weights `wgt`.
-
-!!! info
-    The constructor does not check if every matrix inside `wgt` is Hermitian.
 
 ```jldoctest
 julia> loc = 0:2;
@@ -52,10 +51,7 @@ julia> weights(P) == wgt
 true
 ```
 """
-function PolesSumBlock(loc::AbstractVector, wgt::Vector{<:AbstractMatrix})
-    return PolesSumBlock(loc, map(Hermitian, wgt))
-end
-PolesSumBlock(loc::AbstractVector{A}, wgt::Vector{Hermitian{B, Matrix{B}}}) where {A, B} =
+PolesSumBlock(loc::AbstractVector{A}, wgt::Vector{<:AbstractMatrix{B}}) where {A, B} =
     PolesSumBlock{A, B}(loc, wgt)
 
 """
@@ -105,7 +101,7 @@ function PolesSumBlock(
     # no merging necessary
     if n == 1
         b = @view amp[:, 1]
-        return PolesSumBlock(loc, [Hermitian(b * b')])
+        return PolesSumBlock(loc, [b * b'])
     end
 
     # sort by location
@@ -114,7 +110,7 @@ function PolesSumBlock(
     amp = @view amp[:, p]
 
     loc_new = A[]
-    wgt_new = Hermitian{B, Matrix{B}}[]
+    wgt_new = Matrix{B}[]
 
     i = 1
 
@@ -130,7 +126,7 @@ function PolesSumBlock(
                 w .+= b * b'
             else
                 push!(loc_new, l)
-                push!(wgt_new, Hermitian(w))
+                push!(wgt_new, w)
                 l = loc[i]
                 b = @view amp[:, i]
                 w = b * b'
@@ -138,7 +134,7 @@ function PolesSumBlock(
             i += 1
         end
         push!(loc_new, l)
-        push!(wgt_new, Hermitian(w))
+        push!(wgt_new, w)
     end
 
     # poles in [-tol, tol]
@@ -151,7 +147,7 @@ function PolesSumBlock(
             i += 1
         end
         push!(loc_new, zero(A))
-        push!(wgt_new, Hermitian(w))
+        push!(wgt_new, w)
     end
 
     # poles in (tol, ∞)
@@ -167,7 +163,7 @@ function PolesSumBlock(
                 w .+= b * b'
             else
                 push!(loc_new, l)
-                push!(wgt_new, Hermitian(w))
+                push!(wgt_new, w)
                 l = loc[i]
                 b = @view amp[:, i]
                 w = b * b'
@@ -175,7 +171,7 @@ function PolesSumBlock(
             i += 1
         end
         push!(loc_new, l)
-        push!(wgt_new, Hermitian(w))
+        push!(wgt_new, w)
     end
 
     return PolesSumBlock(loc_new, wgt_new)
@@ -187,7 +183,7 @@ function amplitude(P::PolesSumBlock, i::Integer, tol_amp::Real = 0; thin::Bool =
     tol_amp >= 0 || throw(DomainError(tol_amp, "negative amplitude"))
 
     w = weight(P, i)
-    F = eigen(w)
+    F = eigen(Hermitian(w))
     map!(i -> i > tol_amp^2 ? sqrt(i) : zero(i), F.values) # set small amplitudes to zero
     if !thin
         # General Julia code does not know about semipositive eigenvalues
@@ -278,8 +274,6 @@ function merge_degenerate_poles!(P::PolesSumBlock, tol::Real = 0)
     # get information from P
     loc = locations(P)
     wgt = weights(P)
-    # When adding matrices, Hermitian can't add in-place.
-    # Thus, access H.data directly with parent(H).
 
     # pole(s) at [-tol, tol]
     idx_zeros = findall(i -> abs(i) <= tol, loc)
@@ -287,7 +281,7 @@ function merge_degenerate_poles!(P::PolesSumBlock, tol::Real = 0)
         i0 = popfirst!(idx_zeros)
         loc[i0] = 0
         for i in reverse!(idx_zeros)
-            parent(wgt[i0]) .+= popat!(wgt, i)
+            wgt[i0] .+= popat!(wgt, i)
             deleteat!(loc, i)
         end
     end
@@ -298,7 +292,7 @@ function merge_degenerate_poles!(P::PolesSumBlock, tol::Real = 0)
     while i < lastindex(loc)
         if loc[i + 1] - loc[i] <= tol
             # merge
-            parent(wgt[i]) .+= popat!(wgt, i + 1)
+            wgt[i] .+= popat!(wgt, i + 1)
             deleteat!(loc, i + 1) # keep location closer to zero
         else
             # increment index
@@ -312,7 +306,7 @@ function merge_degenerate_poles!(P::PolesSumBlock, tol::Real = 0)
     while i > firstindex(loc)
         if loc[i] - loc[i - 1] <= tol
             # merge
-            parent(wgt[i - 1]) .+= popat!(wgt, i)
+            wgt[i - 1] .+= popat!(wgt, i)
             deleteat!(loc, i - 1) # keep location closer to zero
             i -= 1
         else
@@ -339,13 +333,13 @@ function merge_small_weight!(P::PolesSumBlock, tol::Real)
         if i == 1
             # add weight to next pole
             wgt_next = weight(P, i + 1)
-            parent(wgt_next) .+= wgt
+            wgt_next .+= wgt
             deleteat!(locations(P), 1)
             deleteat!(weights(P), 1)
         elseif i == length(P)
             # add weight to previous pole
             wgt_prev = weight(P, i - 1)
-            parent(wgt_prev) .+= wgt
+            wgt_prev .+= wgt
             pop!(locations(P))
             pop!(weights(P))
         else
@@ -355,8 +349,8 @@ function merge_small_weight!(P::PolesSumBlock, tol::Real)
             wgt_prev = weight(P, i - 1)
             wgt_next = weight(P, i + 1)
             α = (loc_next - loc) / (loc_next - loc_prev)
-            parent(wgt_prev) .+= α * wgt
-            parent(wgt_next) .+= (1 - α) * wgt
+            wgt_prev .+= α * wgt
+            wgt_next .+= (1 - α) * wgt
             deleteat!(locations(P), i)
             deleteat!(weights(P), i)
         end
@@ -372,7 +366,7 @@ function Base.:+(A::PolesSumBlock{<:Any, TA}, B::PolesSumBlock{<:Any, TB}) where
     loc = [locations(A); locations(B)]
     # copy weights of `A`, `B` to `wgt`
     T = promote_type(TA, TB)
-    wgt = Vector{Hermitian{T, Matrix{T}}}(undef, length(A) + length(B))
+    wgt = Vector{Matrix{T}}(undef, length(A) + length(B))
     for i in eachindex(wgt)
         if i <= length(A)
             wgt[i] = copy(weight(A, i))
@@ -385,7 +379,7 @@ end
 
 function Base.convert(::Type{PolesSumBlock{M, N}}, P::PolesSumBlock{A, B}) where {M, N, A, B}
     loc = convert(Vector{M}, locations(P))
-    wgt = convert.(Hermitian{N, Matrix{N}}, weights(P))
+    wgt = convert.(Matrix{N}, weights(P))
     return PolesSumBlock(loc, wgt)
 end
 Base.convert(::Type{PolesSumBlock{A, B}}, P::PolesSumBlock{A, B}) where {A, B} = P
@@ -408,7 +402,7 @@ Base.size(P::PolesSumBlock) = size(first(weights(P)))
 Base.size(P::PolesSumBlock, i) = size(first(weights(P)), i)
 
 function Base.transpose(P::PolesSumBlock)
-    return PolesSumBlock(copy(locations(P)), map(conj, weights(P)))
+    return PolesSumBlock(copy(locations(P)), map(transpose, weights(P)))
 end
 
 function LinearAlgebra.tr(P::PolesSumBlock{<:Any, B}) where {B}

--- a/src/greens_function.jl
+++ b/src/greens_function.jl
@@ -216,13 +216,13 @@ function greens_function_local(
 
     T = eltype(eltype(H_k)) <: Real ? Float64 : ComplexF64
     loc = real(T)[]
-    wgt = Hermitian{T, Matrix{T}}[]
+    wgt = Matrix{T}[]
     for H in H_k
         E, U = eigen(Hermitian(H))
         append!(loc, E)
         for i in axes(U, 2)
             u = view(U, :, i)
-            push!(wgt, Hermitian(u * u'))
+            push!(wgt, u * u')
         end
     end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -96,10 +96,9 @@ end
 function read_hdf5(filename::AbstractString, ::Type{<:PolesSumBlock{A, B}}) where {A, B}
     return h5open(filename, "r") do fid
         locations::Vector{A} = read(fid, "locations")
-        H = Hermitian{B, Matrix{B}}
-        weights = Vector{H}(undef, length(locations))
+        weights = Vector{Matrix{B}}(undef, length(locations))
         for i in eachindex(locations)
-            weights[i] = Hermitian(read(fid, "weights/$i"))
+            weights[i] = read(fid, "weights/$i")
         end
         return PolesSumBlock(locations, weights)
     end
@@ -109,7 +108,7 @@ function write_hdf5(filename::AbstractString, P::PolesSumBlock)
     h5open(filename, "w") do fid
         fid["locations"] = locations(P)
         for i in eachindex(P)
-            fid["weights/$i"] = parent(weight(P, i))
+            fid["weights/$i"] = weight(P, i)
         end
     end
     return nothing

--- a/src/self_energy.jl
+++ b/src/self_energy.jl
@@ -84,7 +84,7 @@ function self_energy_IFG(C::PolesSumBlock, block::Int = 1)
     B0_inv_sqr = Hermitian(B0_inv_sqr[idx, idx])
     A1 = Hermitian(A1[idx, idx])
     for i in eachindex(P)
-        weights(P)[i] = Hermitian(weight(P, i)[idx, idx]) # potential 1×1 matrix → Hermitian
+        weights(P)[i] = weight(P, i)[idx, idx] # potential 1×1 matrix
     end
 
     # new scaling matrix
@@ -94,7 +94,7 @@ function self_energy_IFG(C::PolesSumBlock, block::Int = 1)
     B0 = Hermitian(F.vectors' * D * F.vectors) # B0
     A1 = B0 * A1 * B0
     for i in eachindex(P)
-        weights(P)[i] = Hermitian(B0 * weight(P, i) * B0)
+        weights(P)[i] = B0 * Hermitian(weight(P, i)) * B0
     end
 
     # diagonalize

--- a/test/Poles/polessumblock.jl
+++ b/test/Poles/polessumblock.jl
@@ -6,14 +6,13 @@ using Test
     @testset "constructor" begin
         loc = 0:1
         wgt = [[1 2; 2 1], [3 4; 4 3]]
-        wgt_h = map(Hermitian, wgt)
 
         # inner constructor
-        P = PolesSumBlock{Int, Int}(loc, wgt_h)
+        P = PolesSumBlock{Int, Int}(loc, wgt)
         @test P.locations == loc
-        @test P.weights == wgt_h
+        @test P.weights == wgt
         @test_throws DimensionMismatch PolesSumBlock(rand(3), wgt) # length mismatch
-        PolesSumBlock([1], [[1 2im; 2im 1]]) # Hermiticity is not enforced
+        @test_throws ArgumentError PolesSumBlock([1], [[1 2im; 2im 1]]) # not hermitian
         @test_throws DimensionMismatch PolesSumBlock(0:1, [[1 2im; -2im 1], [1;;]]) # wrong size
 
         # outer constructors
@@ -29,6 +28,12 @@ using Test
         P = PolesSumBlock(loc_amp, amp, 0.25)
         @test P.locations == [-3.0, -2.5]
         @test P.weights == [[10 14; 14 20], [25 30; 30 36]]
+        loc_amp = [0.0]
+        amp = [1; 2;;]
+        P = PolesSumBlock(loc_amp, amp)
+        @test P.locations == [0.0]
+        @test P.weights == [[1 2; 2 4]]
+
 
         # conversion of type
         P = PolesSumBlock(loc, wgt)
@@ -60,9 +65,9 @@ using Test
             amp = zeros(10, 2)
             amp[3, 1] = 2
             amp[5, 2] = 3
-            P = PolesSumBlock(rand(1), [Hermitian(w)])
+            P = PolesSumBlock(rand(1), [w])
             amp2 = amplitude(P, 1, thin = true)
-            @test norm(amp - amp2) == 0
+            @test amp == amp2
         end # amplitude
 
         @testset "amplitudes" begin
@@ -76,7 +81,7 @@ using Test
 
             # thin with random values
             amps = [rand(ComplexF64, 10, i) for i in 1:10]
-            wghts = [Hermitian(amp * amp') for amp in amps]
+            wghts = [amp * amp' for amp in amps]
             loc = sort!(rand(10))
             P = PolesSumBlock(loc, wghts)
             amps2 = amplitudes(P, sqrt(100 * eps()); thin = true)
@@ -332,7 +337,7 @@ using Test
         end # eltype
 
         @testset "isempty" begin
-            @test isempty(PolesSumBlock(Int[], Hermitian{Float64, Matrix{Float64}}[]))
+            @test isempty(PolesSumBlock(Int[], Matrix{Float64}[]))
             @test !isempty(PolesSumBlock(rand(10), rand(2, 10)))
         end # isempty
 
@@ -344,7 +349,7 @@ using Test
         end # iterate
 
         @testset "length" begin
-            @test length(PolesSumBlock(Int[], Hermitian{Float64, Matrix{Float64}}[])) === 0
+            @test length(PolesSumBlock(Int[], Matrix{Float64}[])) === 0
             @test length(PolesSumBlock(rand(10), rand(4, 10))) === 10
         end
 
@@ -373,7 +378,7 @@ using Test
         end # size
 
         @testset "show" begin
-            P = PolesSumBlock(Int[], Hermitian{Float64, Matrix{Float64}}[])
+            P = PolesSumBlock(Int[], Matrix{Float64}[])
             @test sprint(show, P) == "PolesSumBlock{Int64, Float64} with 0 poles"
             P = PolesSumBlock(rand(Int, 1), [hermitianpart!(rand(Float64, 2, 2))])
             @test sprint(show, P) == "PolesSumBlock{Int64, Float64} with 1 poles of size 2×2"


### PR DESCRIPTION
Do not use `Hermitian` type directly.
Roughly reverts commit `cbb7bfb`.