### PR TITLE
enforce canonical representation for `AbstractPolesSum`

### DIFF
--- a/src/Poles/abstractpolessum.jl
+++ b/src/Poles/abstractpolessum.jl
@@ -2,6 +2,9 @@
     AbstractPolesSum
 
 Supertype which represents a (block) function on the real axis as a sum of poles.
+
+The canonical representation requires the locations to be strictly increasing
+(sorted with no duplicates).
 """
 abstract type AbstractPolesSum <: AbstractPoles end
 

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -5,7 +5,7 @@ Representation of poles on the real axis with locations ``a_i`` of type `A`
 and weights ``w_i`` of type `B`
 
 ```math
-P(ω) = ∑_i \\frac{w_i}{ω-a_i}.
+P(z) = ∑_i \\frac{w_i}{z-a_i}.
 ```
 
 For a block variant see [`PolesSumBlock`](@ref).
@@ -16,10 +16,8 @@ struct PolesSum{A <: Real, B <: Number} <: AbstractPolesSum
 
     function PolesSum{A, B}(locations, weights) where {A, B}
         length(locations) == length(weights) || throw(DimensionMismatch("length mismatch"))
-        result = new{A, B}(locations, weights)
-        sort!(result)
-        merge_degenerate_poles!(result)
-        return result
+        _issorted_and_unique(locations)
+        return new{A, B}(locations, weights)
     end
 end
 
@@ -45,13 +43,33 @@ true
 ```
 """
 function PolesSum(loc::AbstractVector{A}, wgt::AbstractVector{B}) where {A, B}
-    return PolesSum{A, B}(loc, wgt)
+    # Check length for permutation below.
+    length(loc) == length(wgt) || throw(DimensionMismatch("length mismatch"))
+
+    # sort
+    p = sortperm(loc)
+    loc = loc[p]
+    wgt = wgt[p]
+
+    # Merge degenerate locations.
+    loc_out = similar(loc, 0)
+    wgt_out = similar(wgt, 0)
+    i = 1
+    while i <= length(loc)
+        l = loc[i]
+        w = wgt[i]
+        i += 1
+        while i <= length(loc) && loc[i] == l
+            w += wgt[i]
+            i += 1
+        end
+        push!(loc_out, l)
+        push!(wgt_out, w)
+    end
+    return PolesSum{A, B}(loc_out, wgt_out)
 end
 
-# convert type
-function PolesSum{A, B}(P::PolesSum) where {A, B}
-    return PolesSum{A, B}(Vector{A}(locations(P)), Vector{B}(weights(P)))
-end
+PolesSum{A, B}(P::PolesSum) where {A, B} = convert(PolesSum{A, B}, P)
 
 """
     add_pole_at_zero!(P::PolesSum)
@@ -323,22 +341,60 @@ end
 
 weight(P::PolesSum, i::Integer) = weights(P)[i]
 
-function Base.:+(A::PolesSum, B::PolesSum)
-    result = PolesSum([locations(A); locations(B)], [weights(A); weights(B)])
-    sort!(result)
-    merge_degenerate_poles!(result, 0)
-    return result
+function Base.:+(A::PolesSum{LA, WA}, B::PolesSum{LB, WB}) where {LA, WA, LB, WB}
+    L = promote_type(LA, LB)
+    W = promote_type(WA, WB)
+    na, nb = length(A), length(B)
+    loc = Vector{L}(undef, na + nb)
+    wgt = Vector{W}(undef, na + nb)
+    ia = ib = 1
+    k = 1
+    @inbounds while ia <= na || ib <= nb
+        if ia > na
+            loc[k] = location(B, ib)
+            wgt[k] = weight(B, ib)
+            ib += 1
+            k += 1
+        elseif ib > nb
+            loc[k] = location(A, ia)
+            wgt[k] = weight(A, ia)
+            ia += 1
+            k += 1
+        elseif location(A, ia) < location(B, ib)
+            loc[k] = location(A, ia)
+            wgt[k] = weight(A, ia)
+            ia += 1
+            k += 1
+        elseif location(B, ib) < location(A, ia)
+            loc[k] = location(B, ib)
+            wgt[k] = weight(B, ib)
+            ib += 1
+            k += 1
+        else
+            loc[k] = location(A, ia)
+            wgt[k] = weight(A, ia) + weight(B, ib)
+            ia += 1
+            ib += 1
+            k += 1
+        end
+    end
+    resize!(loc, k - 1)
+    resize!(wgt, k - 1)
+    return PolesSum{L, W}(loc, wgt)
 end
 
-function Base.:-(A::PolesSum, B::PolesSum)
-    result = PolesSum([locations(A); locations(B)], [weights(A); -weights(B)])
-    sort!(result)
-    merge_degenerate_poles!(result, 0)
-    return result
+Base.:-(P::PolesSum{A, B}) where {A, B} = PolesSum{A, B}(copy(locations(P)), -weights(P))
+
+Base.:-(A::PolesSum, B::PolesSum) = +(A, -B)
+
+function Base.convert(::Type{PolesSum{M, N}}, P::PolesSum{A, B}) where {M, N, A, B}
+    loc = convert(Vector{M}, locations(P))
+    wgt = convert(Vector{N}, weights(P))
+    return PolesSum{M, N}(loc, wgt)
 end
 
-function Base.copy(P::PolesSum)
-    return PolesSum(copy(locations(P)), copy(weights(P)))
+function Base.copy(P::PolesSum{A, B}) where {A, B}
+    return PolesSum{A, B}(copy(locations(P)), copy(weights(P)))
 end
 
 Base.eltype(::Type{<:PolesSum{A, B}}) where {A, B} = promote_type(A, B)

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -129,12 +129,6 @@ function PolesSumBlock(
 
     n = length(loc)
 
-    # no merging necessary
-    if n == 1
-        b = @view amp[:, 1]
-        return PolesSumBlock{A, B}(loc, [b * b'])
-    end
-
     # sort by location
     p = sortperm(loc)
     loc = loc[p]
@@ -144,62 +138,20 @@ function PolesSumBlock(
     wgt_new = Matrix{B}[]
 
     i = 1
-
-    # poles in (-∞, -tol)
-    if i <= n && loc[i] < -tol
+    while i <= n
         l = loc[i]
         b = @view amp[:, i]
         w = b * b'
         i += 1
-        while i <= n && loc[i] < -tol
-            if loc[i] - l <= tol
-                b = @view amp[:, i]
-                w .+= b * b'
-            else
-                push!(loc_new, l)
-                push!(wgt_new, w)
-                l = loc[i]
-                b = @view amp[:, i]
-                w = b * b'
-            end
-            i += 1
-        end
-        push!(loc_new, l)
-        push!(wgt_new, w)
-    end
-
-    # poles in [-tol, tol]
-    if i <= n && abs(loc[i]) <= tol
-        m = size(amp, 1)
-        w = zeros(B, m, m)
-        while i <= n && abs(loc[i]) <= tol
+        while i <= n && loc[i] - l <= tol
+            # merge degenerate location
             b = @view amp[:, i]
             w .+= b * b'
             i += 1
         end
-        push!(loc_new, zero(A))
-        push!(wgt_new, w)
-    end
-
-    # poles in (tol, ∞)
-    if i <= n
-        l = loc[i]
-        l = l
-        b = @view amp[:, i]
-        w = b * b'
-        i += 1
-        while i <= n
-            if loc[i] - l <= tol
-                b = @view amp[:, i]
-                w .+= b * b'
-            else
-                push!(loc_new, l)
-                push!(wgt_new, w)
-                l = loc[i]
-                b = @view amp[:, i]
-                w = b * b'
-            end
-            i += 1
+        if abs(l) <= tol
+            # enforce pole at zero
+            l = zero(A)
         end
         push!(loc_new, l)
         push!(wgt_new, w)

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -441,12 +441,12 @@ end
 function Base.convert(::Type{PolesSumBlock{M, N}}, P::PolesSumBlock{A, B}) where {M, N, A, B}
     loc = convert(Vector{M}, locations(P))
     wgt = convert.(Matrix{N}, weights(P))
-    return PolesSumBlock(loc, wgt)
+    return PolesSumBlock{M, N}(loc, wgt)
 end
 Base.convert(::Type{PolesSumBlock{A, B}}, P::PolesSumBlock{A, B}) where {A, B} = P
 
-function Base.copy(P::PolesSumBlock)
-    return PolesSumBlock(copy(locations(P)), map(copy, weights(P)))
+function Base.copy(P::PolesSumBlock{A, B}) where {A, B}
+    return PolesSumBlock{A, B}(copy(locations(P)), map(copy, weights(P)))
 end
 
 Base.eltype(::Type{<:PolesSumBlock{A, B}}) where {A, B} = promote_type(A, B)
@@ -462,8 +462,9 @@ end
 Base.size(P::PolesSumBlock) = size(first(weights(P)))
 Base.size(P::PolesSumBlock, i) = size(first(weights(P)), i)
 
-function Base.transpose(P::PolesSumBlock)
-    return PolesSumBlock(copy(locations(P)), map(transpose, weights(P)))
+function Base.transpose(P::PolesSumBlock{A, B}) where {A, B}
+    wgt = [Matrix(transpose(w)) for w in weights(P)]
+    return PolesSumBlock{A, B}(copy(locations(P)), wgt)
 end
 
 function LinearAlgebra.tr(P::PolesSumBlock{<:Any, B}) where {B}

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -5,12 +5,13 @@ Representation of block of poles on the real axis with locations ``a_i`` of type
 and weights ``W_i`` of type `Matrix{B}`.
 
 ```math
-P(ω) = ∑_i \\frac{W_i}{ω-a_i}.
+P(z) = ∑_i \\frac{W_i}{z-a_i}.
 ```
 
 For ``W_i`` to be physical,
 it needs to be Hermitian (``W_i^† = W_i``)
 and positive semidefinite ``W_i ⪰ 0``.
+The latter is not enforced at construction to reduce computational cost.
 
 For a scalar variant see [`PolesSum`](@ref).
 """
@@ -23,15 +24,13 @@ struct PolesSumBlock{A <: Real, B <: Number} <: AbstractPolesSum
         all(ishermitian, weights)::Bool || throw(ArgumentError("weights are not hermitian"))
         allequal(size, weights)::Bool ||
             throw(DimensionMismatch("weights do not have matching size"))
-        result = new{A, B}(locations, weights)
-        sort!(result)
-        merge_degenerate_poles!(result)
-        return result
+        _issorted_and_unique(locations)
+        return new{A, B}(locations, weights)
     end
 end
 
 """
-    PolesSumBlock(loc::AbstractVector, wgt::Vector{<:AbstractMatrix}) where {A,B}
+    PolesSumBlock(loc::AbstractVector{A}, wgt::Vector{<:AbstractMatrix{B}}) where {A, B}
 
 Create a new instance of [`PolesSumBlock`](@ref) by supplying locations `loc`
 and weights `wgt`.
@@ -51,8 +50,40 @@ julia> weights(P) == wgt
 true
 ```
 """
-PolesSumBlock(loc::AbstractVector{A}, wgt::Vector{<:AbstractMatrix{B}}) where {A, B} =
-    PolesSumBlock{A, B}(loc, wgt)
+function PolesSumBlock(loc::AbstractVector{A}, wgt::Vector{<:AbstractMatrix{B}}) where {A, B}
+    # Check length for permutation below.
+    length(loc) == length(wgt) || throw(DimensionMismatch("length mismatch"))
+
+    # Do no mutate user input.
+    loc = collect(A, loc)
+    wgt = [copy(w) for w in wgt]
+    for w in wgt
+        isapprox(w, w') || throw(ArgumentError("weight is not hermitian"))
+        ishermitian(w) || hermitianpart!(w)
+    end
+
+    # sort
+    p = sortperm(loc)
+    loc = loc[p]
+    wgt = wgt[p]
+
+    # Merge degenerate locations.
+    loc_out = similar(loc, 0)
+    wgt_out = similar(wgt, 0)
+    i = 1
+    while i <= length(loc)
+        l = loc[i]
+        w = copy(wgt[i])
+        i += 1
+        while i <= length(loc) && loc[i] == l
+            w .+= wgt[i]
+            i += 1
+        end
+        push!(loc_out, l)
+        push!(wgt_out, w)
+    end
+    return PolesSumBlock{A, B}(loc_out, wgt_out)
+end
 
 """
     PolesSumBlock(
@@ -101,7 +132,7 @@ function PolesSumBlock(
     # no merging necessary
     if n == 1
         b = @view amp[:, 1]
-        return PolesSumBlock(loc, [b * b'])
+        return PolesSumBlock{A, B}(loc, [b * b'])
     end
 
     # sort by location
@@ -174,7 +205,7 @@ function PolesSumBlock(
         push!(wgt_new, w)
     end
 
-    return PolesSumBlock(loc_new, wgt_new)
+    return PolesSumBlock{A, B}(loc_new, wgt_new)
 end
 
 PolesSumBlock{A, B}(P::PolesSumBlock) where {A, B} = convert(PolesSumBlock{A, B}, P)

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -393,19 +393,49 @@ function moment(P::PolesSumBlock, n::Int = 0)
     return sum(i -> i[1]^n * i[2], zip(locations(P), weights(P)))
 end
 
-function Base.:+(A::PolesSumBlock{<:Any, TA}, B::PolesSumBlock{<:Any, TB}) where {TA, TB}
-    loc = [locations(A); locations(B)]
-    # copy weights of `A`, `B` to `wgt`
-    T = promote_type(TA, TB)
-    wgt = Vector{Matrix{T}}(undef, length(A) + length(B))
-    for i in eachindex(wgt)
-        if i <= length(A)
-            wgt[i] = copy(weight(A, i))
+function Base.:+(A::PolesSumBlock{LA, WA}, B::PolesSumBlock{LB, WB}) where {LA, WA, LB, WB}
+    L = promote_type(LA, LB)
+    W = promote_type(WA, WB)
+    na, nb = length(A), length(B)
+    loc = Vector{L}(undef, na + nb)
+    wgt = Vector{Matrix{W}}(undef, na + nb)
+    ia = ib = 1
+    k = 1
+    @inbounds while ia <= na || ib <= nb
+        if ia > na
+            loc[k] = location(B, ib)
+            wgt[k] = Matrix{W}(weight(B, ib))
+            ib += 1
+            k += 1
+        elseif ib > nb
+            loc[k] = location(A, ia)
+            wgt[k] = Matrix{W}(weight(A, ia))
+            ia += 1
+            k += 1
+        elseif location(A, ia) < location(B, ib)
+            loc[k] = location(A, ia)
+            wgt[k] = Matrix{W}(weight(A, ia))
+            ia += 1
+            k += 1
+        elseif location(B, ib) < location(A, ia)
+            loc[k] = location(B, ib)
+            wgt[k] = Matrix{W}(weight(B, ib))
+            ib += 1
+            k += 1
         else
-            wgt[i] = copy(weight(B, i - length(A)))
+            # merge degenerate locations
+            loc[k] = location(A, ia)
+            w = Matrix{W}(weight(A, ia))
+            w .+= convert(Matrix{W}, weight(B, ib))
+            wgt[k] = w
+            ia += 1
+            ib += 1
+            k += 1
         end
     end
-    return PolesSumBlock(loc, wgt)
+    resize!(loc, k - 1)
+    resize!(wgt, k - 1)
+    return PolesSumBlock{L, W}(loc, wgt)
 end
 
 function Base.convert(::Type{PolesSumBlock{M, N}}, P::PolesSumBlock{A, B}) where {M, N, A, B}

--- a/test/Poles/polessum.jl
+++ b/test/Poles/polessum.jl
@@ -5,29 +5,45 @@ using Test
 
 @testset "PolesSum" begin
     @testset "constructor" begin
-        loc = 0:5
-        wgt = 5:10
+        @testset "inner constructor" begin
+            loc = [0, 1]
+            wgt = [2, 3]
+            P = PolesSum{Int, Int}(loc, wgt)
+            @test P isa PolesSum{Int, Int}
+            @test P.locations === loc
+            @test P.weights === wgt
+            # length mismatch
+            @test_throws DimensionMismatch PolesSum{Int, Int}(rand(3), rand(4))
+            @test_throws DimensionMismatch PolesSum{Int, Int}(rand(4), rand(3))
+            PolesSumBlock{Int, Float64}(Int[], Float64[]) # empty lists
+        end # inner constructor
 
-        # inner constructor
-        P = PolesSum{Int, Int}(loc, wgt)
-        @test typeof(P) === PolesSum{Int, Int}
-        @test P.locations == loc
-        @test P.weights == wgt
-        # length mismatch
-        @test_throws DimensionMismatch PolesSum{Int, Int}(rand(3), rand(4))
-        @test_throws DimensionMismatch PolesSum{Int, Int}(rand(4), rand(3))
+        @testset "outer constructors" begin
+            # canonical form
+            loc = [0, 1]
+            wgt = [2, 3]
+            P = PolesSum(loc, wgt)
+            @test P.locations == loc
+            @test P.locations !== loc
+            @test P.weights == wgt
+            @test P.weights !== wgt
 
-        # outer constructor
-        P = PolesSum(loc, wgt)
-        @test P.locations == loc
-        @test P.weights == wgt
+            # sort and merge degenerate poles
+            loc = [0, 1, 0]
+            wgt = [2, 3, 4]
+            P = PolesSum(loc, wgt)
+            @test P.locations == [0, 1]
+            @test P.weights == [6, 3]
 
-        # conversion of type
-        P = PolesSum(loc, wgt)
-        P_new = PolesSum{UInt, Float64}(P)
-        @test typeof(P_new) === PolesSum{UInt, Float64}
-        @test P_new.locations == loc
-        @test P_new.weights == wgt
+            # conversion of type
+            loc = [0, 1]
+            wgt = [2, 3]
+            P = PolesSum(loc, wgt)
+            P_new = PolesSum{UInt, Float64}(P)
+            @test P_new isa PolesSum{UInt, Float64}
+            @test P_new.locations == loc
+            @test P_new.weights == wgt
+        end # outer constructors
     end # constructor
 
     @testset "custom functions" begin
@@ -204,7 +220,7 @@ using Test
             # equidistant grid
             loc = [-0.5, 0.5, 1.5]
             wgt = [1.5, -0.5, 5.0]
-            P = merge_negative_weight!(PolesSum(loc, wgt))
+            P = merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test locations(P) === loc
             @test weights(P) === wgt
             @test loc == [-0.5, 0.5, 1.5]
@@ -212,37 +228,37 @@ using Test
             # not equidistant grid
             loc = [-0.5, 0.0, 1.5]
             wgt = [1.5, -0.5, 5.0]
-            merge_negative_weight!(PolesSum(loc, wgt))
+            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test loc == [-0.5, 0.0, 1.5]
             @test wgt == [1.125, 0.0, 4.875]
             # first pole negative
             loc = [0.0, 1.0, 5.0]
             wgt = [-1.0, 0.5, 2.25]
-            merge_negative_weight!(PolesSum(loc, wgt))
+            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test loc == [0.0, 1.0, 5.0]
             @test wgt == [0.0, 0.0, 1.75]
             # last pole negative
             loc = [0.0, 1.0, 5.0]
             wgt = [2.25, 0.5, -1.0]
-            merge_negative_weight!(PolesSum(loc, wgt))
+            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test loc == [0.0, 1.0, 5.0]
             @test wgt == [1.75, 0.0, 0.0]
             # weight exactly cancel
             loc = [0.0, 1.0, 5.0]
             wgt = [-1.0, 0.5, 0.5]
-            merge_negative_weight!(PolesSum(loc, wgt))
+            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test loc == [0.0, 1.0, 5.0]
             @test wgt == [0.0, 0.0, 0.0]
             # symmetric case
             loc = [-2.0, -0.5, 0.0, 0.5, 2.0]
             wgt = [5.0, -2.0, 1.0, -2.0, 5.0]
-            merge_negative_weight!(PolesSum(loc, wgt))
+            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test loc == [-2.0, -0.5, 0.0, 0.5, 2.0]
             @test norm(wgt - [3.5, 0.0, 0.0, 0.0, 3.5]) < 10 * eps()
             # previous pole would get negative weight
             loc = [-1.0, -0.5, 0.0, 1.5]
             wgt = [2.0, 1.5, -2.5, 5.0]
-            merge_negative_weight!(PolesSum(loc, wgt))
+            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
             @test loc == [-1.0, -0.5, 0.0, 1.5]
             @test wgt == [1.7, 0.0, 0.0, 4.3]
         end # merge_negative_weight!
@@ -388,34 +404,39 @@ using Test
 
     @testset "Base" begin
         @testset "+" begin
-            # addition must sort resulting poles
-            A = PolesSum([0.1, 0.3, 0.2], [0.1, 0.3, 0.2])
-            B = PolesSum([0.6, 0.5, 0.4], [6, 5, 4])
-            P = A + B
-            @test locations(P) == [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
-            @test weights(P) == [0.1, 0.2, 0.3, 4.0, 5.0, 6.0]
             # addition must merge degenerate poles
-            A = PolesSum([0.1, 0.2], [0.1, 0.25])
-            B = PolesSum([0.2], [1])
+            A = PolesSum([1, 3], [4, 5])
+            B = PolesSum([2, 3], [6, 7])
             P = A + B
-            @test locations(P) == [0.1, 0.2]
-            @test weights(P) == [0.1, 1.25]
+            @test locations(P) == [1, 2, 3]
+            @test weights(P) == [4, 6, 12]
         end
 
         @testset "-" begin
-            # subtraction must sort resulting poles
-            A = PolesSum([0.1, 0.3, 0.2], [0.1, 0.3, 0.2])
-            B = PolesSum([0.6, 0.5, 0.4], [6, 5, 4])
-            P = A - B
-            @test locations(P) == [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
-            @test weights(P) == [0.1, 0.2, 0.3, -4.0, -5.0, -6.0]
-            # addition must merge degenerate poles
+            # unary
+            P = PolesSum([1, 2], [3, 4])
+            P_new = -P
+            @test locations(P_new) == [1, 2]
+            @test locations(P_new) !== locations(P)
+            @test weights(P_new) == -[3, 4]
+
+            # subtraction must merge degenerate poles
             A = PolesSum([0.1, 0.2], [0.1, 0.25])
             B = PolesSum([0.2], [1])
             P = A - B
             @test locations(P) == [0.1, 0.2]
             @test weights(P) == [0.1, -0.75]
         end # -
+
+        @testset "convert" begin
+            P = PolesSum([1, 3], [0, 2])
+            P_new = convert(PolesSum{Float64, ComplexF64}, P)
+            @test P_new isa PolesSum{Float64, ComplexF64}
+            @test locations(P_new) == locations(P)
+            @test weights(P_new) == weights(P)
+            P_new = convert(PolesSum{Int, Int}, P)
+            @test P_new === P
+        end # convert
 
         @testset "copy" begin
             loc = 1:5

--- a/test/Poles/polessumblock.jl
+++ b/test/Poles/polessumblock.jl
@@ -341,9 +341,11 @@ using Test
         @testset "convert" begin
             P = PolesSumBlock([1, 3], [[1 0; 0 1], [2 1; 1 0]])
             P_new = convert(PolesSumBlock{Float64, ComplexF64}, P)
-            @test typeof(P_new) === PolesSumBlock{Float64, ComplexF64}
+            @test P_new isa PolesSumBlock{Float64, ComplexF64}
             @test locations(P_new) == locations(P)
             @test weights(P_new) == weights(P)
+            P_new = convert(PolesSumBlock{Int, Int}, P)
+            @test P_new === P
         end # convert
 
         @testset "copy" begin

--- a/test/Poles/polessumblock.jl
+++ b/test/Poles/polessumblock.jl
@@ -328,13 +328,14 @@ using Test
 
     @testset "Base" begin
         @testset "+" begin
-            # addition must sort and merge poles
+            # addition must merge degenerate poles
             A = PolesSumBlock([1, 3], [[1 0; 0 1], [2 1; 1 0]])
-            B = PolesSumBlock([3, 2], [[4 5; 5 6], [0 0; 0 0]])
+            B = PolesSumBlock([2, 3], [[0 0; 0 0], [4 5; 5 6]])
             P = A + B
-            @test locations(P) == [1, 2, 3] # must be sorted
+            @test locations(P) == [1, 2, 3]
             @test weights(P) == [[1 0; 0 1], [0 0; 0 0], [6 6; 6 6]]
             @test weight(P, 1) !== weight(A, 1)
+            @test weight(P, 2) !== weight(B, 1)
         end
 
         @testset "convert" begin

--- a/test/Poles/polessumblock.jl
+++ b/test/Poles/polessumblock.jl
@@ -3,45 +3,68 @@ using LinearAlgebra
 using Test
 
 @testset "PolesSumBlock" begin
-    @testset "constructor" begin
-        loc = 0:1
-        wgt = [[1 2; 2 1], [3 4; 4 3]]
+    @testset "constructors" begin
+        @testset "inner constructor" begin
+            loc = [0, 1]
+            wgt = [[1 2; 2 1], [3 4; 4 3]]
+            P = PolesSumBlock{Int, Int}(loc, wgt)
+            @test P.locations === loc
+            @test P.weights === wgt
+            @test @allocated(PolesSumBlock{Int, Int}(loc, wgt)) == 0 # no allocations
+            @test_throws DimensionMismatch PolesSumBlock{Int, Int}(rand(Int, 3), wgt) # length mismatch
+            @test_throws ArgumentError PolesSumBlock{Int, Complex{Int}}([1], [[1 2im; 2im 1]]) # not Hermitian
+            @test_throws DimensionMismatch PolesSumBlock{Int, Int}([0, 1], [[1 2im; -2im 1], [1;;]]) # weights wrong size
+            PolesSumBlock{Int, Float64}(Int[], Matrix{Float64}[]) # empty lists
+        end # inner constructor
 
-        # inner constructor
-        P = PolesSumBlock{Int, Int}(loc, wgt)
-        @test P.locations == loc
-        @test P.weights == wgt
-        @test_throws DimensionMismatch PolesSumBlock(rand(3), wgt) # length mismatch
-        @test_throws ArgumentError PolesSumBlock([1], [[1 2im; 2im 1]]) # not hermitian
-        @test_throws DimensionMismatch PolesSumBlock(0:1, [[1 2im; -2im 1], [1;;]]) # wrong size
+        @testset "outer constructors" begin
+            # canonical form
+            loc = [0, 1]
+            wgt = [[1 2; 2 1], [3 4; 4 3]]
+            P = PolesSumBlock(loc, wgt)
+            @test P.locations == loc
+            @test P.locations !== loc
+            @test P.weights == wgt
+            @test P.weights !== wgt
 
-        # outer constructors
-        P = PolesSumBlock(loc, wgt)
-        @test P.locations == loc
-        @test P.weights == wgt
-        P = PolesSumBlock(loc, [1 + 2im 3im; 4 5 + 6im])
-        @test P.locations == loc
-        @test P.weights == [[5 4 + 8im; 4 - 8im 16], [9 18 + 15im; 18 - 15im 61]]
-        # correct merging of degenerate poles
-        loc_amp = [-3.0, -2.5, -2.75]
-        amp = [1 5 3; 2 6 4]
-        P = PolesSumBlock(loc_amp, amp, 0.25)
-        @test P.locations == [-3.0, -2.5]
-        @test P.weights == [[10 14; 14 20], [25 30; 30 36]]
-        loc_amp = [0.0]
-        amp = [1; 2;;]
-        P = PolesSumBlock(loc_amp, amp)
-        @test P.locations == [0.0]
-        @test P.weights == [[1 2; 2 4]]
+            # sort and merge degenerate poles
+            loc = [0, 1, 0]
+            wgt = [[1 2; 2 1], [3 4; 4 3], [5 6; 6 5]]
+            P = PolesSumBlock(loc, wgt)
+            @test P.locations == [0, 1]
+            @test P.weights == [[6 8; 8 6], [3 4; 4 3]]
 
+            # supply amplitudes
+            loc = [0, 1]
+            amp = [1 + 2im 3im; 4 5 + 6im]
+            P = PolesSumBlock(loc, amp)
+            @test P.locations == [0, 1]
+            @test P.weights == [[5 4 + 8im; 4 - 8im 16], [9 18 + 15im; 18 - 15im 61]]
 
-        # conversion of type
-        P = PolesSumBlock(loc, wgt)
-        P_new = PolesSumBlock{UInt, Float64}(P)
-        @test typeof(P_new) === PolesSumBlock{UInt, Float64}
-        @test P_new.locations == loc
-        @test P_new.weights == wgt
-    end # constructor
+            # correct merging of degenerate poles
+            loc = [-3.0, -2.5, -2.75]
+            amp = [1 5 3; 2 6 4]
+            P = PolesSumBlock(loc, amp, 0.25)
+            @test P.locations == [-3.0, -2.5]
+            @test P.weights == [[10 14; 14 20], [25 30; 30 36]]
+
+            # single pole
+            loc = [0.0]
+            amp = [1; 2;;]
+            P = PolesSumBlock(loc, amp)
+            @test P.locations == [0.0]
+            @test P.weights == [[1 2; 2 4]]
+
+            # conversion of type
+            loc = [0, 1]
+            wgt = [[1 2; 2 1], [3 4; 4 3]]
+            P = PolesSumBlock(loc, wgt)
+            P_new = PolesSumBlock{UInt, Float64}(P)
+            @test P_new isa PolesSumBlock{UInt, Float64}
+            @test P_new.locations == loc
+            @test P_new.weights == wgt
+        end # outer constructors
+    end # constructors
 
     @testset "custom functions" begin
         @testset "amplitude" begin


### PR DESCRIPTION
The canonical representation requires the locations to be strictly increasing
(sorted with no duplicates).