### PR TITLE
clean up `Poles`

### DIFF
--- a/src/Poles/conversion.jl
+++ b/src/Poles/conversion.jl
@@ -145,7 +145,7 @@ function PolesContinuedFractionBlock(P::PolesSumBlock)
     # Q1 = vcat(amp...) is type-unstable
     T = eltype(eltype(amp))
     Q1 = Matrix{T}(undef, n1 * n2, n2)
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         i1 = 1 + (i - 1) * n2
         i2 = i * n2
         Q1[i1:i2, :] = amp[i]
@@ -155,7 +155,7 @@ function PolesContinuedFractionBlock(P::PolesSumBlock)
     _orthonormalize_GramSchmidt!(Q1) # numerical instability
     # set small values to zero
     tol = sqrt(eps()) * norm(scl)
-    for i in eachindex(scl)
+    @inbounds for i in eachindex(scl)
         scl[i] < tol && (scl[i] = 0)
     end
     # block Lanczos with full orthogonalization

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -194,67 +194,91 @@ end
 """
     merge_negative_weight!(P::PolesSum)
 
-Move negative weights of `P` such that the zeroth moment is conserved
-and the first moment changes minimally.
+Remove negative weights of `P` such that
+the zeroth (total weight) and first moment are conserved.
+
+For each pole with negative weight at index `i`,
+the weight is merged to neighbors using the law of levers.
+
+!!! warning
+    For negative outermost poles, the first moment is **not conserved**.
+
+Poles with zero weight after merging are automatically removed.
 """
 function merge_negative_weight!(P::PolesSum)
     # check input
-    moment(P, 0) >= 0 || throw(ArgumentError("total weight is negative"))
+    m0 = moment(P, 0)
+    m0 >= 0 || throw(
+        ArgumentError("total weight is negative: $(m0)."),
+    )
 
-    loc = locations(P)
-    wgt = weights(P)
-    for i in eachindex(P)
-        (weight(P, i) >= 0) && continue # no negative weight, go to next
+    locs = locations(P)
+    wgts = weights(P)
+    i = 1
+    while i <= length(P)
+        wgts[i] > 0 && (i += 1; continue)
+
+        if iszero(wgts[i])
+            deleteat!(locs, i)
+            deleteat!(wgts, i)
+            continue
+        end
+
+        # single pole with negative weight
+        i == 1 && length(P) == 1 && throw(
+            ArgumentError("Single pole has negative weight $(wgts[1])."),
+        )
+
+        # first pole
+        if i == 1
+            wgts[2] += wgts[1]
+            deleteat!(locs, 1)
+            deleteat!(wgts, 1)
+            continue
+        end
+
+        # last pole
         if i == length(P)
-            # find previous positive weight
-            for j in Iterators.reverse(1:(i - 1))
-                iszero(wgt[j]) && continue
-                if wgt[j] + wgt[end] >= 0
-                    # wgt[j] can fully compensate wgt[end]
-                    wgt[j] += wgt[end]
-                    wgt[end] = 0
-                    break
-                else
-                    # wgt[j] can't fully compensate wgt[end]
-                    wgt[end] += wgt[j]
-                    wgt[j] = 0
-                end
-            end
-        else
-            for j in Iterators.reverse(1:(i - 1))
-                # find a previous pole with positive weight
-                iszero(wgt[j]) && continue
-                # calculate fractions how weight should be split
-                f_left = (loc[i + 1] - loc[i]) / (loc[i + 1] - loc[j])
-                f_right = 1 - f_left
-                if wgt[j] + f_left * wgt[i] >= 0
-                    # wgt[j] can fully compensate wgt[i]
-                    wgt[j] += f_left * wgt[i]
-                    wgt[i + 1] += f_right * wgt[i]
-                    wgt[i] = 0
-                else
-                    # wgt[j] can't fully compensate wgt[i].
-                    # Find fraction f ∈ (0, 1) which can be merged such that wgt[j] gets 0 weight.
-                    # b_j + f f_l b_i === 0
-                    wgt[i] += wgt[j] / f_left
-                    wgt[i + 1] -= f_right / f_left * wgt[j]
-                    wgt[j] = 0
-                end
-                if j == 1
-                    # no pole with positive weight remaining
-                    wgt[i + 1] += wgt[i]
-                    wgt[i] = 0
-                end
-            end
-            if wgt[i] <= 0
-                # negative weight remaining and no previous weight to compensate
-                # move negative weight to next pole
-                wgt[i + 1] += wgt[i]
-                wgt[i] = 0
+            wgts[end - 1] += wgts[end]
+            deleteat!(locs, i)
+            deleteat!(wgts, i)
+            i -= 1
+            continue
+        end
+
+        # search leftward for compensation
+        j = i - 1
+        while true
+            # lever rule split between j and i+1
+            f_left = (locs[i + 1] - locs[i]) / (locs[i + 1] - locs[j])
+            f_right = 1 - f_left
+            need_left = -f_left * wgts[i]  # amount needed from left
+
+            if wgts[j] >= need_left
+                # w_j can fully compensate w_i.
+                wgts[j] -= need_left
+                wgts[i + 1] += f_right * wgts[i]
+                deleteat!(locs, i)
+                deleteat!(wgts, i)
+                i = j
+                break
+            else
+                # w_j can't fully compensate w_i.
+                # Find fraction f ∈ (0, 1) which can be merged such that w_j becomes 0.
+                # w_j + f f_l w_i == 0
+                wgts[i] += wgts[j] / f_left
+                wgts[i + 1] -= f_right / f_left * wgts[j]
+                deleteat!(locs, j)
+                deleteat!(wgts, j)
+                j -= 1
+                i -= 1
+
+                # no more left neighbors
+                j < 1 && break
             end
         end
     end
-    moment(P, 0) >= 0 || throw(ArgumentError("total weight got negative"))
+
     return P
 end
 

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -86,6 +86,14 @@ function add_pole_at_zero!(P::PolesSum)
 end
 
 amplitude(P::PolesSum{<:Any, <:Real}, i::Integer) = sqrt(weight(P, i))
+function amplitude(P::PolesSum{<:Any, <:Complex}, i::Integer)
+    throw(
+        DomainError(
+            weight(P, i),
+            "amplitude for complex weight not defined"
+        )
+    )
+end
 
 function arrowhead_matrix(P::PolesSum)
     amps = amplitudes(P)

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -101,7 +101,7 @@ function arrowhead_matrix(P::PolesSum)
     n = length(P) + 1
     result = zeros(T, n, n)::Matrix{T}
 
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         result[i + 1, i + 1] = location(P, i)
     end
     result[1, 2:end] .= amps
@@ -113,7 +113,7 @@ end
 function evaluate_gaussian(P::PolesSum, ω::Real, σ::Real)
     real = zero(ω)
     imag = zero(ω)
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         w = weight(P, i)
         real += w * sqrt(2) / (π * σ) * dawson((ω - location(P, i)) / (sqrt(2) * σ))
         imag += w * pdf(Normal(location(P, i), σ), ω)
@@ -124,7 +124,7 @@ end
 
 function evaluate_lorentzian(P::PolesSum, ω::Real, δ::Real)
     result = zero(complex(ω))
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         result += weight(P, i) / (ω + im * δ - location(P, i))
     end
     return result
@@ -351,7 +351,7 @@ b_i δ(ω) →
 function spectral_function_loggaussian(P::PolesSum, ω::Real, b::Real)
     result = zero(ω)
     iszero(ω) && return result # no weight at ω == 0
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         if sign(ω) == sign(location(P, i))
             # only contribute weight if on same side of real axis
             w = weight(P, i)
@@ -457,7 +457,7 @@ function LinearAlgebra.axpby!(α::Number, x::P, β::Number, y::P) where {P <: Po
     ly = locations(y)
     sizehint!(ly, length(y) + length(x))
     sizehint!(wy, length(y) + length(x))
-    @inline for i in eachindex(x)
+    @inbounds @inline for i in eachindex(x)
         push!(ly, lx[i])
         push!(wy, α * wx[i])
     end

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -432,7 +432,7 @@ end
 Base.eltype(::Type{<:PolesSum{A, B}}) where {A, B} = promote_type(A, B)
 
 function Base.inv(P::PolesSum)
-    isapprox(moment(P, 0), 1; atol = 1000 * eps()) ||
+    isapprox(moment(P, 0), 1; atol = 1000 * eps(float(eltype(P)))) ||
         throw(ArgumentError("P does not have total weight 1"))
 
     b0, HA = anderson_matrix(P)

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -215,7 +215,7 @@ function evaluate_gaussian(P::PolesSumBlock, ω::Real, σ::Real)
     # dot multiplication loses Hermiticity
     real = zeros(ComplexF64, d, d) # weights can be complex
     imag = zero(real)
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         w = weight(P, i)
         real .+= w .* sqrt(2) ./ (π * σ) .* dawson((ω - location(P, i)) / (sqrt(2) * σ))
         imag .+= w .* pdf(Normal(location(P, i), σ), ω)
@@ -228,7 +228,7 @@ end
 function evaluate_lorentzian(P::PolesSumBlock, ω::Real, δ::Real)
     d = size(P, 1)
     result = zeros(ComplexF64, d, d)
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         w = weight(P, i)
         result .+= w ./ (ω + im * δ - location(P, i))
     end
@@ -423,7 +423,7 @@ function LinearAlgebra.tr(P::PolesSumBlock{<:Any, B}) where {B}
     loc = copy(locations(P))
     wgt = similar(loc, real(B))
 
-    for i in eachindex(P)
+    @inbounds for i in eachindex(P)
         wgt[i] = tr(weight(P, i))
     end
     return PolesSum(loc, wgt)

--- a/test/Poles/polessum.jl
+++ b/test/Poles/polessum.jl
@@ -72,6 +72,12 @@ using Test
             @test amplitude(P, 5) == sqrt(9)
             @test amplitude(P, 6) == sqrt(10)
             @test_throws BoundsError amplitude(P, 7)
+
+            # complex weight
+            loc = [1]
+            wgt = [5 + 3im]
+            P = PolesSum(loc, wgt)
+            @test_throws DomainError amplitude(P, 1)
         end # amplitude
 
         @testset "amplitudes" begin
@@ -80,9 +86,9 @@ using Test
             P = PolesSum(loc, wgt)
             @test amplitudes(P) == sqrt.(5:10)
             # errors
-            P = PolesSum(loc, rand(ComplexF64, 6))
-            @test_throws MethodError amplitudes(P)
             P = PolesSum(loc, -wgt)
+            @test_throws DomainError amplitudes(P)
+            P = PolesSum(loc, rand(ComplexF64, 6))
             @test_throws DomainError amplitudes(P)
         end # amplitudes
 

--- a/test/Poles/polessum.jl
+++ b/test/Poles/polessum.jl
@@ -226,47 +226,52 @@ using Test
             # equidistant grid
             loc = [-0.5, 0.5, 1.5]
             wgt = [1.5, -0.5, 5.0]
-            P = merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test locations(P) === loc
-            @test weights(P) === wgt
-            @test loc == [-0.5, 0.5, 1.5]
-            @test wgt == [1.25, 0.0, 4.75]
+            P = PolesSum(loc, wgt)
+            @test merge_negative_weight!(P) === P
+            @test locations(P) == [-0.5, 1.5]
+            @test weights(P) == [1.25, 4.75]
+
             # not equidistant grid
             loc = [-0.5, 0.0, 1.5]
             wgt = [1.5, -0.5, 5.0]
-            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test loc == [-0.5, 0.0, 1.5]
-            @test wgt == [1.125, 0.0, 4.875]
+            P = merge_negative_weight!(PolesSum(loc, wgt))
+            @test locations(P) == [-0.5, 1.5]
+            @test weights(P) == [1.125, 4.875]
+
             # first pole negative
             loc = [0.0, 1.0, 5.0]
             wgt = [-1.0, 0.5, 2.25]
-            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test loc == [0.0, 1.0, 5.0]
-            @test wgt == [0.0, 0.0, 1.75]
+            P = merge_negative_weight!(PolesSum(loc, wgt))
+            @test locations(P) == [5.0]
+            @test weights(P) == [1.75]
+
             # last pole negative
             loc = [0.0, 1.0, 5.0]
             wgt = [2.25, 0.5, -1.0]
-            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test loc == [0.0, 1.0, 5.0]
-            @test wgt == [1.75, 0.0, 0.0]
-            # weight exactly cancel
+            P = merge_negative_weight!(PolesSum(loc, wgt))
+            @test locations(P) == [0.0]
+            @test weights(P) == [1.75]
+
+            # total weight zero
             loc = [0.0, 1.0, 5.0]
             wgt = [-1.0, 0.5, 0.5]
-            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test loc == [0.0, 1.0, 5.0]
-            @test wgt == [0.0, 0.0, 0.0]
+            P = merge_negative_weight!(PolesSum(loc, wgt))
+            @test locations(P) == Float64[]
+            @test weights(P) == Float64[]
+
             # symmetric case
             loc = [-2.0, -0.5, 0.0, 0.5, 2.0]
-            wgt = [5.0, -2.0, 1.0, -2.0, 5.0]
-            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test loc == [-2.0, -0.5, 0.0, 0.5, 2.0]
-            @test norm(wgt - [3.5, 0.0, 0.0, 0.0, 3.5]) < 10 * eps()
+            wgt = [4.0, -2.0, 1.0, -2.0, 4.0]
+            P = merge_negative_weight!(PolesSum(loc, wgt))
+            @test locations(P) == [-2.0, 2.0]
+            @test weights(P) == [2.5, 2.5]
+
             # previous pole would get negative weight
             loc = [-1.0, -0.5, 0.0, 1.5]
             wgt = [2.0, 1.5, -2.5, 5.0]
-            merge_negative_weight!(PolesSum{Float64, Float64}(loc, wgt))
-            @test loc == [-1.0, -0.5, 0.0, 1.5]
-            @test wgt == [1.7, 0.0, 0.0, 4.3]
+            P = merge_negative_weight!(PolesSum(loc, wgt))
+            @test locations(P) == [-1.0, 1.5]
+            @test weights(P) == [1.7, 4.3]
         end # merge_negative_weight!
 
         @testset "merge_small_weight!" begin


### PR DESCRIPTION
Use `@inbounds` where possible.
Merging negative weight removes poles with zero weight.