### PR TITLE
feat(poles): add generic `evaluate(P, z)`

### DIFF
--- a/src/Poles/abstractpoles.jl
+++ b/src/Poles/abstractpoles.jl
@@ -34,13 +34,24 @@ See also [`amplitude`](@ref) for details of `args...` and `kwargs...`.
 function amplitudes end
 
 """
+    evaluate(P::AbstractPoles, z)
+
+Evaluate `P` at the complex variable `z`.
+
+See also [`evaluate_gaussian`](@ref), [`evaluate_lorentzian`](@ref).
+"""
+function evaluate end
+function evaluate(P::AbstractPoles, z::AbstractVector{<:Number})
+    return map(i -> evaluate(P, i), z)
+end
+
+"""
     evaluate_gaussian(P::AbstractPoles, ω, σ)
 
 Evaluate `P` with Gaussian broadening ``σ``.
 """
 function evaluate_gaussian end
 function evaluate_gaussian(P::AbstractPoles, ω::AbstractVector{<:Real}, σ)
-    # map for each point in given grid
     return map(i -> evaluate_gaussian(P, i, σ), ω)
 end
 
@@ -51,7 +62,6 @@ Evaluate `P` with Lorentzian broadening ``P(ω + \\mathrm{i}δ)``.
 """
 function evaluate_lorentzian end
 function evaluate_lorentzian(P::AbstractPoles, ω::AbstractVector{<:Real}, δ)
-    # map for each point in given grid
     return map(i -> evaluate_lorentzian(P, i, δ), ω)
 end
 

--- a/src/Poles/polescontinuedfraction.jl
+++ b/src/Poles/polescontinuedfraction.jl
@@ -45,16 +45,18 @@ function PolesContinuedFraction{A, B}(P::PolesContinuedFraction) where {A, B}
     )
 end
 
-function evaluate_lorentzian(P::PolesContinuedFraction, ω::Real, δ::Real)
-    result = zero(ComplexF64)
+function evaluate(P::PolesContinuedFraction, z::Number)
+    result = zero(complex(float(eltype(P))))
     locs = Iterators.reverse(locations(P))
     amps = Iterators.reverse(amplitudes(P))
     for (a, b) in zip(locs, amps)
-        result = abs2(b) / (ω + im * δ - a - result)
+        result = abs2(b) / (z - a - result)
     end
-    result = abs2(scale(P)) / (ω + im * δ - location(P, 1) - result)
+    result = abs2(scale(P)) / (z - location(P, 1) - result)
     return result
 end
+
+evaluate_lorentzian(P::PolesContinuedFraction, ω::Real, δ::Real) = evaluate(P, ω + im * δ)
 
 tridiagonal_matrix(P::PolesContinuedFraction) = Matrix(SymTridiagonal(P))
 

--- a/src/Poles/polescontinuedfractionblock.jl
+++ b/src/Poles/polescontinuedfractionblock.jl
@@ -75,16 +75,18 @@ function PolesContinuedFractionBlock(
     return PolesContinuedFractionBlock{A, B}(locs, amps, scl)
 end
 
-function evaluate_lorentzian(P::PolesContinuedFractionBlock, ω::Real, δ::Real)
-    result = zeros(ComplexF64, size(P))
+function evaluate(P::PolesContinuedFractionBlock, z::Number)
+    result = zeros(complex(float(eltype(P))), size(P))
     locs = Iterators.reverse(locations(P))
     amps = Iterators.reverse(amplitudes(P))
     for (A, B) in zip(locs, amps)
-        result = B * inv((ω + im * δ) * I - A - result) * B
+        result = B * inv(z * I - A - result) * B
     end
-    result = scale(P) * inv((ω + im * δ) * I - location(P, 1) - result) * scale(P)
+    result = scale(P) * inv(z * I - location(P, 1) - result) * scale(P)
     return result
 end
+
+evaluate_lorentzian(P::PolesContinuedFractionBlock, ω::Real, δ::Real) = evaluate(P, ω + im * δ)
 
 function tridiagonal_matrix(P::PolesContinuedFractionBlock)
     n1 = length(P)

--- a/src/Poles/polessum.jl
+++ b/src/Poles/polessum.jl
@@ -110,25 +110,26 @@ function arrowhead_matrix(P::PolesSum)
     return result
 end
 
-function evaluate_gaussian(P::PolesSum, ω::Real, σ::Real)
-    real = zero(ω)
-    imag = zero(ω)
-    @inbounds for i in eachindex(P)
-        w = weight(P, i)
-        real += w * sqrt(2) / (π * σ) * dawson((ω - location(P, i)) / (sqrt(2) * σ))
-        imag += w * pdf(Normal(location(P, i), σ), ω)
-    end
-    result = real - im * imag
-    return π * result # not spectral function
-end
-
-function evaluate_lorentzian(P::PolesSum, ω::Real, δ::Real)
-    result = zero(complex(ω))
-    @inbounds for i in eachindex(P)
-        result += weight(P, i) / (ω + im * δ - location(P, i))
+function evaluate(P::PolesSum, z::Number)
+    result = zero(complex(float(eltype(P))))
+    for (ϵ, w) in P
+        result += w / (z - ϵ)
     end
     return result
 end
+
+function evaluate_gaussian(P::PolesSum, ω::Real, σ::Real)
+    result = zero(complex(float(eltype(P))))
+    for (ϵ, w) in P
+        re = sqrt(2) / σ * dawson((ω - ϵ) / (sqrt(2) * σ))
+        im_part = pdf(Normal(ϵ, σ), ω)
+        z = re - im * π * im_part
+        result += w * z
+    end
+    return result
+end
+
+evaluate_lorentzian(P::PolesSum, ω::Real, δ::Real) = evaluate(P, ω + im * δ)
 
 function filling(P::PolesSum{<:Any, B}, μ::Real = 0) where {B}
     result = zero(Float64) # half weight changes Int → Float

--- a/src/Poles/polessumblock.jl
+++ b/src/Poles/polessumblock.jl
@@ -210,30 +210,26 @@ function arrowhead_matrix(P::PolesSumBlock, args...; kwargs...)
     return result
 end
 
-function evaluate_gaussian(P::PolesSumBlock, ω::Real, σ::Real)
-    d = size(P, 1)
-    # dot multiplication loses Hermiticity
-    real = zeros(ComplexF64, d, d) # weights can be complex
-    imag = zero(real)
-    @inbounds for i in eachindex(P)
-        w = weight(P, i)
-        real .+= w .* sqrt(2) ./ (π * σ) .* dawson((ω - location(P, i)) / (sqrt(2) * σ))
-        imag .+= w .* pdf(Normal(location(P, i), σ), ω)
+function evaluate(P::PolesSumBlock, z::Number)
+    result = zeros(complex(float(eltype(P))), size(P))
+    @inbounds for (ϵ, w) in P
+        result .+= w .* inv(z - ϵ)
     end
-    result = real - im * imag
-    result .*= π # not spectral function
     return result
 end
 
-function evaluate_lorentzian(P::PolesSumBlock, ω::Real, δ::Real)
-    d = size(P, 1)
-    result = zeros(ComplexF64, d, d)
-    @inbounds for i in eachindex(P)
-        w = weight(P, i)
-        result .+= w ./ (ω + im * δ - location(P, i))
+function evaluate_gaussian(P::PolesSumBlock, ω::Real, σ::Real)
+    result = zeros(complex(float(eltype(P))), size(P))
+    @inbounds for (ϵ, w) in P
+        re = sqrt(2) / σ * dawson((ω - ϵ) / (sqrt(2) * σ))
+        im_part = pdf(Normal(ϵ, σ), ω)
+        z = re - im * π * im_part
+        result .+= w .* z
     end
     return result
 end
+
+evaluate_lorentzian(P::PolesSumBlock, ω::Real, δ::Real) = evaluate(P, ω + im * δ)
 
 function filling(P::PolesSumBlock{<:Any, B}, μ::Real = 0) where {B}
     result = zeros(B <: Real ? Float64 : ComplexF64, size(P)) # half weight changes Int → Float

--- a/src/RAS_DMFT.jl
+++ b/src/RAS_DMFT.jl
@@ -37,6 +37,7 @@ export
     discretize_similar_weight,
     discretize_to_grid,
     equal_weight_discretization,
+    evaluate,
     evaluate_gaussian,
     evaluate_lorentzian,
     filling,

--- a/test/Poles/polescontinuedfraction.jl
+++ b/test/Poles/polescontinuedfraction.jl
@@ -57,17 +57,38 @@ using Test
             @test amplitudes(P) == amps
         end # amplitudes
 
+        @testset "evaluate" begin
+            locs = [-1.0, 0.0, 2.0]
+            amps = [0.6, 0.4]
+            scl = 1.1
+            P = PolesContinuedFraction(locs, amps, scl)
+            # upper/lower complex plane
+            z = 0.5 + 1.0im
+            @test evaluate(P, z) ≈ 0.47743341980552373 - 0.44522565484288634im atol =
+                10 * eps()
+            @test evaluate(P, conj(z)) == conj(evaluate(P, z))
+            # Matsubara frequency
+            z = 2im
+            @test evaluate(P, z) ≈ 0.21044536856932053 - 0.45960359514387283im atol =
+                10 * eps()
+            @test evaluate(P, conj(z)) == conj(evaluate(P, z))
+            # grid
+            zs = [0.1 + 0.5im, 0.3 + 0.5im]
+            @test evaluate(P, zs) == [evaluate(P, zs[1]), evaluate(P, zs[2])]
+        end # evaluate
+
         @testset "evaluate_lorentzian" begin
-            locs = 1.0:10
-            amps = 0.1:0.1:0.9
+            locs = [-1.0, 0.0, 2.0]
+            amps = [0.6, 0.4]
             scl = 1.1
             # single point
             P = PolesContinuedFraction(locs, amps, scl)
-            @test evaluate_lorentzian(P, 10, 1) ≈
-                0.13282211074263575 - 0.014762307781571633im atol = 10 * eps()
+            @test evaluate_lorentzian(P, 0.5, 1) ≈
+                0.47743341980552373 - 0.44522565484288634im atol = 10 * eps()
             # grid
-            @test evaluate_lorentzian(P, [0.1, 0.3], 0.5) ==
-                [evaluate_lorentzian(P, 0.1, 0.5), evaluate_lorentzian(P, 0.3, 0.5)]
+            ω = [0.1, 0.3]
+            @test evaluate_lorentzian(P, ω, 0.5) ==
+                [evaluate_lorentzian(P, ω[1], 0.5), evaluate_lorentzian(P, ω[2], 0.5)]
         end # evaluate_lorentzian
 
         @testset "locations" begin

--- a/test/Poles/polescontinuedfractionblock.jl
+++ b/test/Poles/polescontinuedfractionblock.jl
@@ -69,6 +69,36 @@ using Test
             @test amplitudes(P) === amps
         end # amplitudes
 
+        @testset "evaluate" begin
+            locs = [[1 2; 2 3], [4 5; 5 6]]
+            amps = [[7 8; 8 9]]
+            scl = [10 11; 11 12]
+            P = PolesContinuedFractionBlock(locs, amps, scl)
+            # upper/lower complex plane
+            z = 0.5 + 1.0im
+            @test norm(
+                evaluate(P, z) - [
+                    9.3868717682668326 - 1.7247467522667106im 10.275713626756321 - 1.872408526521784im
+                    10.275713626756325 - 1.8724085265217789im 11.250661306616291 - 2.0359262909579234im
+                ],
+            ) < 100 * eps()
+            @test norm(evaluate(P, conj(z)) - conj.(permutedims(evaluate(P, z)))) <
+                100 * eps()
+            # Matsubara frequency
+            z = 2im
+            @test norm(
+                evaluate(P, z) - [
+                    9.6216882806905861 - 3.3491825125308288im 10.540934044076694 - 3.6580774126819939im
+                    10.540934044076694 - 3.6580774126819948im 11.548094518259207 - 3.9976827909937138im
+                ],
+            ) < 100 * eps()
+            @test norm(evaluate(P, conj(z)) - conj.(permutedims(evaluate(P, z)))) <
+                100 * eps()
+            # grid
+            zs = [0.1 + 0.5im, 0.3 + 0.5im]
+            @test evaluate(P, zs) == [evaluate(P, zs[1]), evaluate(P, zs[2])]
+        end # evaluate
+
         @testset "evaluate_lorentzian" begin
             locs = [[1 2; 2 3], [4 5; 5 6]]
             amps = [[7 8; 8 9]]
@@ -76,14 +106,15 @@ using Test
             P = PolesContinuedFractionBlock(locs, amps, scl)
             # single point
             @test norm(
-                evaluate_lorentzian(P, 10, 1) - [
-                    0.10758121432383735 - 0.8486851180203552im 0.1192067097465451 - 0.9291288301545801im
-                    0.11920670974654493 - 0.92912883015458im 0.132513408476524 - 1.0172414419361508im
+                evaluate_lorentzian(P, 0.5, 1) - [
+                    9.3868717682668326 - 1.7247467522667106im 10.275713626756321 - 1.872408526521784im
+                    10.275713626756325 - 1.8724085265217789im 11.250661306616291 - 2.0359262909579234im
                 ],
             ) < 10 * eps()
             # grid
-            @test evaluate_lorentzian(P, [0.1, 0.3], 0.5) ==
-                [evaluate_lorentzian(P, 0.1, 0.5), evaluate_lorentzian(P, 0.3, 0.5)]
+            ω = [0.1, 0.3]
+            @test evaluate_lorentzian(P, ω, 0.5) ==
+                [evaluate_lorentzian(P, ω[1], 0.5), evaluate_lorentzian(P, ω[2], 0.5)]
         end # evaluate_lorentzian
 
         @testset "locations" begin

--- a/test/Poles/polessum.jl
+++ b/test/Poles/polessum.jl
@@ -1,5 +1,4 @@
 using RAS_DMFT
-using Distributions: Semicircle, pdf
 using LinearAlgebra
 using Test
 
@@ -92,37 +91,51 @@ using Test
             @test_throws DomainError amplitudes(P)
         end # amplitudes
 
+        @testset "evaluate" begin
+            locs = [-1.0, 0.0, 2.0]
+            wgts = [0.2, 0.3, 0.5]
+            P = PolesSum(locs, wgts)
+            # upper/lower complex plane
+            z = 0.5 + 1.0im
+            @test evaluate(P, z) ≈ -0.018461538461538474 - 0.4553846153846154im atol =
+                10 * eps()
+            @test evaluate(P, conj(z)) == conj(evaluate(P, z))
+            # Matsubara frequency
+            z = 2im
+            @test evaluate(P, z) ≈ -0.085 - 0.355im atol =
+                10 * eps()
+            @test evaluate(P, conj(z)) == conj(evaluate(P, z))
+            # grid
+            zs = [0.1 + 0.5im, 0.3 + 0.5im]
+            @test evaluate(P, zs) == [evaluate(P, zs[1]), evaluate(P, zs[2])]
+        end # evaluate
+
         @testset "evaluate_gaussian" begin
-            locs = [0.1, 0.2]
-            wgts = [0.01, 0.09]
+            locs = [-1.0, 0.0, 2.0]
+            wgts = [0.2, 0.3, 0.5]
             P = PolesSum(locs, wgts)
             # single point
-            ω = 0.15
-            σ = 0.04
-            @test evaluate_gaussian(P, ω, σ) ≈ -1.5277637226549838 - 1.4345225621076145im atol =
+            ω = 0.5
+            σ = 1.0
+            @test evaluate_gaussian(P, ω, σ) ≈ -0.08753757822014871 - 0.6166378221821291im atol =
                 10 * eps()
-            # semicircular DOS
-            G = greens_function_bethe_simple(3001)
-            ω = -3:0.01:3
-            σ = 0.01
-            # constant broadening
-            h = evaluate_gaussian(G, ω, σ)
-            ex = π .* pdf.(Semicircle(1), ω) # exact solution
-            @test norm(ex + imag(h)) < 0.2
-            @test maximum(abs.(ex + imag(h))) < 0.12
-            @test findmin(imag(h))[2] == cld(length(ω), 2) # symmetric
+            # grid
+            ω = [0.1, 0.3]
+            @test evaluate_gaussian(P, ω, 0.5) ==
+                [evaluate_gaussian(P, ω[1], 0.5), evaluate_gaussian(P, ω[2], 0.5)]
         end # evaluate_gaussian
 
         @testset "evaluate_lorentzian" begin
-            locs = 1.0:10
-            wgts = abs2.(0.1:0.1:1)
+            locs = [-1.0, 0.0, 2.0]
+            wgts = [0.2, 0.3, 0.5]
             P = PolesSum(locs, wgts)
             # single point
-            @test evaluate_lorentzian(P, 10, 1) ≈ 0.9853493892744969 - 1.619653515362841im atol =
+            @test evaluate_lorentzian(P, 0.5, 1) ≈ -0.018461538461538474 - 0.4553846153846154im atol =
                 10 * eps()
             # grid
-            @test evaluate_lorentzian(P, [0.1, 0.3], 0.5) ==
-                [evaluate_lorentzian(P, 0.1, 0.5), evaluate_lorentzian(P, 0.3, 0.5)]
+            ω = [0.1, 0.3]
+            @test evaluate_lorentzian(P, ω, 0.5) ==
+                [evaluate_lorentzian(P, ω[1], 0.5), evaluate_lorentzian(P, ω[2], 0.5)]
         end # evaluate_lorentzian
 
         @testset "filling" begin

--- a/test/Poles/polessumblock.jl
+++ b/test/Poles/polessumblock.jl
@@ -116,37 +116,68 @@ using Test
             end
         end # amplitudes
 
+        @testset "evaluate" begin
+            locs = [-1.0, 0.0, 2.0]
+            amps = reshape(0.2:0.1:0.7, (2, 3))
+            P = PolesSumBlock(locs, amps)
+            # upper/lower complex plane
+            z = 0.5 + 1.0im
+            @test norm(
+                evaluate(P, z) - [
+                    -0.083692307692307677 - 0.25107692307692314im -0.08615384615384615 - 0.30769230769230771im
+                    -0.08615384615384615 - 0.30769230769230771im -0.084615384615384592 - 0.37846153846153846im
+                ],
+            ) < 100 * eps()
+            @test evaluate(P, conj(z)) == conj.(permutedims(evaluate(P, z)))
+            # Matsubara frequency
+            z = 2im
+            @test norm(
+                evaluate(P, z) - [
+                    -0.082 - 0.186im -0.093 - 0.229im
+                    -0.093 - 0.229im -0.1045 - 0.2835im
+                ],
+            ) < 100 * eps()
+            @test evaluate(P, conj(z)) == conj.(permutedims(evaluate(P, z)))
+            # grid
+            zs = [0.1 + 0.5im, 0.3 + 0.5im]
+            @test evaluate(P, zs) == [evaluate(P, zs[1]), evaluate(P, zs[2])]
+        end # evaluate
+
         @testset "evaluate_gaussian" begin
-            ω = 0.15
-            σ = 0.04
-            locs = [0.1, 0.2]
-            amps = reshape(0.1:0.1:0.4, (2, 2))
+            ω = 0.5
+            σ = 1.0
+            locs = [-1.0, 0.0, 2.0]
+            amps = reshape(0.2:0.1:0.7, (2, 3))
             P = PolesSumBlock(locs, amps)
             @test norm(
                 evaluate_gaussian(P, ω, σ) - [
-                    -1.5277637226549838 - 1.4345225621076145im -1.90970465331873 - 2.00833158695066im
-                    -1.90970465331873 - 2.00833158695066im -2.2916455839824765 - 2.8690451242152295im
+                    -0.16702850198727615 - 0.33972394588525767im -0.178700179083296 - 0.41651710181548046im
+                    -0.178700179083296 - 0.41651710181548046im -0.18576841335312091 - 0.51250854672825896im
                 ],
             ) < 10 * eps()
+            # grid
+            ω = [0.1, 0.3]
+            @test evaluate_gaussian(P, ω, 0.5) ==
+                [evaluate_gaussian(P, ω[1], 0.5), evaluate_gaussian(P, ω[2], 0.5)]
         end # evaluate_gaussian
 
         @testset "evaluate_lorentzian" begin
-            ω = 10.0
+            ω = 0.5
             δ = 1.0
-            locs = 1.0:10
-            amps = reshape(0.1:0.1:2, (2, 10))
+            locs = [-1.0, 0.0, 2.0]
+            amps = reshape(0.2:0.1:0.7, (2, 3))
             # single point
             P = PolesSumBlock(locs, amps)
             @test norm(
                 evaluate_lorentzian(P, ω, δ) - [
-                    3.419109056634164 - 5.796080126589452im 3.669440321902302 - 6.127487634859227im
-                    3.669440321902302 - 6.127487634859227im 3.9413975570979876 - 6.478614061451364im
+                    -0.083692307692307677 - 0.25107692307692314im -0.08615384615384615 - 0.30769230769230771im
+                    -0.08615384615384615 - 0.30769230769230771im -0.084615384615384592 - 0.37846153846153846im
                 ],
             ) < eps()
             # grid
-            ω = rand(2)
-            @test evaluate_lorentzian(P, ω, δ) ==
-                [evaluate_lorentzian(P, ω[1], δ), evaluate_lorentzian(P, ω[2], δ)]
+            ω = [0.1, 0.3]
+            @test evaluate_lorentzian(P, ω, 0.5) ==
+                [evaluate_lorentzian(P, ω[1], 0.5), evaluate_lorentzian(P, ω[2], 0.5)]
         end # evaluate_lorentzian
 
         @testset "filling" begin


### PR DESCRIPTION
Evaluate `P` on a complex number `z`.
Also unify tests between `evaluate`, `evaluate_gaussian`, and `evaluate_lorentzian` to use the same quantities.