### PR TITLE
test: use exactly-representable input

### DIFF
--- a/test/orthogonalization.jl
+++ b/test/orthogonalization.jl
@@ -54,18 +54,13 @@ using Test
     end # _orthonormalize_SVD
 
     @testset "_orthonormalize_GramSchmidt!" begin
-        V1 = [0 3 1; 0 0 1; 100 * eps() 8 0]
+        V1 = [0 0 3; 0 0 0; 100 * eps() 2 1]
         @test RAS_DMFT._orthonormalize_GramSchmidt!(V1) === V1
         @test view(V1, :, 1) == zeros(3)
-        @test view(V1, :, 2) == 1 / sqrt(73) * [3, 0, 8]
-        v3 = [64, 73, -24] / 73
-        normalize!(v3)
-        @test norm(view(V1, :, 3) - v3) < eps()
-        # applying again has small changes
-        foo = copy(V1)
-        @test RAS_DMFT._orthonormalize_GramSchmidt!(V1) != foo
+        @test view(V1, :, 2) == [0, 0, 1]
+        @test view(V1, :, 3) == [1, 0, 0]
         @test V1' * V1 == Diagonal([0, 1, 1])
-        # applying again should keep it equal
+        # applying again keeps it unchanged
         foo = copy(V1)
         @test RAS_DMFT._orthonormalize_GramSchmidt!(V1) == foo
 


### PR DESCRIPTION
Previous values break with Julia 1.13-rc2.